### PR TITLE
Fixes a checkout bug related to Member addresses

### DIFF
--- a/code/checkout/components/MembershipCheckoutComponent.php
+++ b/code/checkout/components/MembershipCheckoutComponent.php
@@ -114,6 +114,22 @@ class MembershipCheckoutComponent extends CheckoutComponent{
 		$member = $factory->create($data);
 		$member->write();
 		$member->logIn();
+
+		if ($order->BillingAddressID) {
+			$address = $order->getBillingAddress();
+			$address->MemberID = $member->ID;
+			$address->write();
+			$member->DefaultBillingAddressID = $order->BillingAddressID;
+		}
+		if ($order->ShippingAddressID) {
+			$address = $order->getShippingAddress();
+			$address->MemberID = $member->ID;
+			$address->write();
+			$member->DefaultShippingAddressID = $order->ShippingAddressID;
+		}
+		if ($member->isChanged()) {
+			$member->write();
+		}
 	}
 
 	public function setConfirmed($confirmed) {


### PR DESCRIPTION
Given a single-page checkout and given the membership component comes after the address book components, the addresses don't get assigned to the member correctly. Supercedes #276.