### PR TITLE
Added hooks for ajax integration

### DIFF
--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -104,7 +104,9 @@ class VariationForm extends AddProductForm {
 
 		$this->extend('updateVariationAddToCart', $form, $variation);
 
-		ShoppingCart_Controller::direct();
+		$request = $this->getRequest();
+		$this->extend('updateVariationFormResponse', $request, $response, $variation, $quantity, $form);
+		return $response ? $response : ShoppingCart_Controller::direct();
 	}
 
 	public function getBuyable($data = null) {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
 		"burnbright/silverstripe-shop-coloredvariations" : "Select colours for variations",
 		"burnbright/silverstripe-shop-geocoding" : "Geocoding support for addresses and visitors.",
 		"burnbright/silverstripe-shop-googleanalytics": "Records shop sales sales in google analytics.",
-		"tractorcow/silverstripe-opengraph": "Implementation of the Facebook Opengraph protocol for Silverstripe."
+		"tractorcow/silverstripe-opengraph": "Implementation of the Facebook Opengraph protocol for Silverstripe",
+		"markguinn/silverstripe-shop-ajax": "Basic ajax behaviours for add to cart, etc"
 	},
 	"extra" : {
 		"installer-name": "shop",


### PR DESCRIPTION
This PR doesn't add full ajax support but it adds extension hooks to make that happen. In the mean time, so that these features can be used safely in modules, I've separated the actual features into a couple modules. I felt the ajax module itself could be useful outside of the shop module so I think we should probably leave it separate. If you want to merge the shop-ajax module into shop core to keep from having two sets of pull requests in the future, I'm totally fine with that.

- https://github.com/markguinn/silverstripe-ajax
- https://github.com/markguinn/silverstripe-shop-ajax

This is a resubmission of #275 because that PR failed Travis/Scrutinizer (due to timeouts). Since that issue has been resolved I'm resubmitting this.