### PR TITLE
Update SteppedCheckoutPage.ss

### DIFF
--- a/templates/Layout/SteppedCheckoutPage.ss
+++ b/templates/Layout/SteppedCheckoutPage.ss
@@ -1,6 +1,13 @@
 <% require ThemedCSS(checkout,shop) %>
 <h1>$Title</h1>
 
+<% if PaymentErrorMessage %>
+	<p class="message error">
+		<% _t('CheckoutPage.PaymentErrorMessage', 'Received error from payment gateway:') %>
+		$PaymentErrorMessage
+	</p>
+<% end_if %>
+
 <% if Cart %>
 
 	<div class="row">


### PR DESCRIPTION
Include the PaymentErrorMessage (just like CheckoutPage.ss) to alert a failure from an offsite payment gateway