### PR TITLE
Email refactor + improvement

### DIFF
--- a/code/checkout/OrderEmail.php
+++ b/code/checkout/OrderEmail.php
@@ -3,6 +3,7 @@
 /**
  * This class handles the receipt email which gets sent once an order is made.
  * You can call it by issuing sendReceipt() in the Order class.
+ * @deprecated 2.0 Use Email instead, and set template
  */
 class Order_ReceiptEmail extends Email {
 
@@ -12,6 +13,7 @@ class Order_ReceiptEmail extends Email {
 /**
  * This class handles the status email which is sent after changing the attributes
  * in the report (eg. status changed to 'Shipped').
+ * @deprecated 2.0 Use Email instead, and set template
  */
 class Order_StatusEmail extends Email {
 

--- a/code/checkout/OrderEmailNotifier.php
+++ b/code/checkout/OrderEmailNotifier.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Handles email notifications to customers and / or admins.
+ *
+ * @package shop
+ */
+class OrderEmailNotifier{
+
+	protected $order;
+
+	public static function create(Order $order) {
+		return Injector::inst()->create('OrderEmailNotifier', $order);
+	}
+
+	/**
+	 * Assign the order to a local variable
+	 * @param Order $order
+	 */
+	public function __construct(Order $order) {
+		$this->order = $order;
+	}
+
+	
+	/**
+	* Send a mail of the order to the client (and another to the admin).
+	*
+	* @param $template - the class name of the email you wish to send
+	* @param $subject - subject of the email
+	* @param $copyToAdmin - true by default, whether it should send a copy to the admin
+	*/
+	public function sendEmail($template, $subject, $copyToAdmin = true) {
+		$from = ShopConfig::config()->email_from ? ShopConfig::config()->email_from : Email::config()->admin_email;
+		$to = $this->order->getLatestEmail();
+		$checkoutpage = CheckoutPage::get()->first();
+		$completemessage = $checkoutpage ? $checkoutpage->PurchaseComplete : "";
+		$email = new Email();
+		$email->setTemplate($template);
+		$email->setFrom($from);
+		$email->setTo($to);
+		$email->setSubject($subject);
+		if($copyToAdmin){
+			$email->setBcc(Email::config()->admin_email);
+		}
+		$email->populateTemplate(array(
+			'PurchaseCompleteMessage' => $completemessage,
+			'Order' => $this->order,
+			'BaseURL' => Director::absoluteBaseURL()
+		));
+
+		return $email->send();
+	}
+
+	/**
+	 * Send customer a confirmation that the order has been received
+	 */
+	public function sendConfirmation() {
+		$subject = sprintf(
+			_t("OrderNotifier.CONFIRMATIONSUBJECT", "Order #%d Confirmation"),
+			$this->order->Reference
+		);
+		$this->sendEmail(
+			'Order_ConfirmationEmail',
+			$subject,
+			self::config()->bcc_confirmation_to_admin
+		);
+	}
+
+	/**
+	 * Notify store owner about new order.
+	 */
+	public function sendAdminNotification() {
+		$subject = sprintf(
+			_t("OrderNotifier.ADMINNOTIFICATIONSUBJECT", "Order #%d Notification"),
+			$this->order->Reference
+		);
+		$this->sendEmail(
+			'Order_AdminNotificationEmail', $subject, false
+		);
+	}
+
+	/**
+	* Send customer an order receipt email.
+	* Precondition: The order payment has been successful
+	*/
+	public function sendReceipt() {
+		$subject = sprintf(
+			_t("OrderNotifier.RECEIPTSUBJECT", "Order #%d Receipt"),
+			$this->order->Reference
+		);
+		$this->sendEmail(
+			'Order_ReceiptEmail',
+			$subject,
+			self::config()->bcc_receipt_to_admin
+		);
+		$this->order->ReceiptSent = SS_Datetime::now()->Rfc2822();
+		$this->order->write();
+	}
+
+	/**
+	* Send a message to the client containing the latest
+	* note of {@link OrderStatusLog} and the current status.
+	*
+	* Used in {@link OrderReport}.
+	*
+	* @param string $note Optional note-content (instead of using the OrderStatusLog)
+	*/
+	public function sendStatusChange($title, $note = null) {
+		if(!$note) {
+			$latestLog = OrderStatusLog::get()
+				->filter("OrderID", $this->order->ID)
+				->filter("SentToCustomer", 1)
+				->first();
+			
+			if($latestLog) {
+				$note = $latestLog->Note;
+				$title = $latestLog->Title;
+			}
+		}
+		$member = $this->order->Member();
+		if(Config::inst()->get('OrderProcessor', 'receipt_email')) {
+			$adminEmail = Config::inst()->get('OrderProcessor', 'receipt_email');
+		} else {
+			$adminEmail = Email::config()->admin_email;
+		}
+		$e = new Order_statusEmail();
+		$e->populateTemplate(array(
+			"Order" => $this->order,
+			"Member" => $member,
+			"Note" => $note
+		));
+		$e->setFrom($adminEmail);
+		$e->setSubject($title);
+		$e->setTo($member->Email);
+		$e->send();
+	}
+
+	public static function config() {
+		return new Config_ForClass("OrderEmailNotifier");
+	}
+
+}

--- a/docs/en/02_Customisation/Emails.md
+++ b/docs/en/02_Customisation/Emails.md
@@ -1,0 +1,36 @@
+Shop emails can be customised to suit your project needs.
+
+## Enable / disable sending of emails
+
+There are a few yaml config options that will affect which emails are sent:
+```yaml
+OrderProcessor:
+    #send order confirmation when order is placed, but unpaid
+    send_confirmation: true
+
+#send a bcc copy of emails to administrator
+OrderEmailNotifier:
+    bcc_confirmation_to_admin: true
+    bcc_receipt_to_admin: true
+
+#Specify the 'from' address to use in email correspondence
+ShopConfig:
+    email_from: store@website.com
+
+```
+
+## Modifying templates
+
+Update email content by overriding the templates inside the `templates/email/` folder. Just create a corresponding folder/template in your mysite folder, such as `mysite/templates/email/Order_RecieptEmail`.
+
+## Modifying subject lines
+
+Email subjects are in the translation system, so you can do the following to change an email subject line:
+
+mysite/lang/en.yml:
+```yaml
+en:
+  OrderNotifier:
+    RECEIPTSUBJECT: 'My Website Order #%d Receipt'
+```
+

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -16,7 +16,7 @@ This has been left for the store owner to collaborate with their developer.
 
 ## [Customisation](Customisation)
 
-* Emails
+* [Emails](Emails)
 * [Sub-modules - stock, discounts ...](Submodules)
 * [Templates and Theming](Templates_and_Themes)
 * [Recipes](Recipes) - how do build in various features.

--- a/templates/email/Order_AdminNotificationEmail.ss
+++ b/templates/email/Order_AdminNotificationEmail.ss
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" >
+		<title><% _t("TITLE","Shop Receipt") %></title>
+		<% include OrderReceiptStyle %>
+	</head>
+	<body>
+		<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
+			<thead>
+				<tr>
+					<th scope="col" colspan="2">
+						<h1 class="title">$Subject</h1>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<% if Order %>
+					<% loop Order %>
+						<tr>
+							<td>
+								<% include Order %>
+							</td>
+						</tr>
+					<% end_loop %>
+				<% end_if %>
+			</tbody>
+		</table>
+	</body>
+</html>

--- a/templates/email/Order_ConfirmationEmail.ss
+++ b/templates/email/Order_ConfirmationEmail.ss
@@ -1,0 +1,35 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" >
+		<title><% _t("TITLE", "Order Confirmation") %></title>
+		<% include OrderReceiptStyle %>
+	</head>
+	<body>
+		<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
+			<thead>
+				<tr>
+					<th scope="col" colspan="2">
+						<h1 class="title">$Subject</h1>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td scope="row" colspan="2" class="typography">
+						$PurchaseCompleteMessage
+					</td>
+				</tr>
+				<% if Order %>
+				<% loop Order %>
+					<tr>
+						<td>
+							<% include Order %>
+						</td>
+					</tr>
+				<% end_loop %>
+				<% end_if %>
+			</tbody>
+		</table>
+	</body>
+</html>


### PR DESCRIPTION
I've added in a 'confirmation email' , which gets sent when an order is placed, but not yet paid for. Receipt is sent after payment.

Also added a AdminNotification email. The email notification to the admin sometimes needs to be different.

Refactored OrderProcessor email stuff into its own class.

Updated docs