### PR TITLE
Update AccountPage.php for Country saved as null

### DIFF
--- a/code/account/AccountPage.php
+++ b/code/account/AccountPage.php
@@ -162,7 +162,14 @@ class AccountPage_Controller extends Page_Controller {
 		$address = new Address();
 		$form->saveInto($address);
 		$address->MemberID = $member->ID;
+
+		// Add value for Country if missing (due readonly field in form)
+		if($country = SiteConfig::current_site_config()->getSingleCountry()){
+			$address->Country = $country;
+		}
+
 		$address->write();
+
 		if(!$member->DefaultShippingAddressID){
 			$member->DefaultShippingAddressID = $address->ID;
 			$member->write();

--- a/code/checkout/CheckoutForm.php
+++ b/code/checkout/CheckoutForm.php
@@ -16,6 +16,13 @@ class CheckoutForm extends Form {
 			)
 	);
 		$validator = new CheckoutComponentValidator($this->config);
+		
+		// For single country sites, the Country field is readonly therefore no need to validate
+		if(SiteConfig::current_site_config()->getSingleCountry()){
+			$validator->removeRequiredField("ShippingAddressCheckoutComponent_Country");
+			$validator->removeRequiredField("BillingAddressCheckoutComponent_Country");
+		}
+
 		parent::__construct($controller, $name, $fields, $actions, $validator);
 		//load data from various sources
 		$this->loadDataFrom($this->config->getData(), Form::MERGE_IGNORE_FALSEISH);

--- a/code/model/Address.php
+++ b/code/model/Address.php
@@ -203,4 +203,15 @@ class Address extends DataObject{
 		$this->Company = $val;
 	}
 
+
+	function validate() {
+	    $result = parent::validate();
+	    foreach(self::$required_fields as $requirement){
+	        if(empty($this->$requirement)) {
+	            $result->error("Address Model validate function - missing required field: $requirement");
+	        }
+	    }
+    	return $result;
+	}
+
 }

--- a/tests/checkout/CheckoutComponentTest.php
+++ b/tests/checkout/CheckoutComponentTest.php
@@ -2,30 +2,123 @@
 
 class CheckoutComponentTest extends SapphireTest {
 
-	public function testSinglePageConfig() {
+	protected static $fixture_file = array(
+		'shop/tests/fixtures/Orders.yml',
+		'shop/tests/fixtures/Addresses.yml',
+		'shop/tests/fixtures/shop.yml',
+		'shop/tests/fixtures/ShopMembers.yml'
+	);
 
+	public function setUp() {
+		parent::setUp();
 		ShopTest::setConfiguration();
+		$this->cart = $this->objFromFixture("Order", "cart1");
+		$this->address1 = $this->objFromFixture("Address", "address1");
+		$this->address2 = $this->objFromFixture("Address", "address2");
+		$this->addressNoCountry = $this->objFromFixture("Address", "pukekohe");
+		CheckoutConfig::config()->member_creation_enabled = true;
+		CheckoutConfig::config()->membership_required = false;
+	}
 
-		//start a new order
-		$order = new Order();
+	public function testSinglePageConfig() {
+		$order = new Order();  //start a new order
 		$order->write();
-
 		$config = new SinglePageCheckoutComponentConfig($order);
 
+		$customerdetailscomponent = $config->getComponentByType("CustomerDetailsCheckoutComponent");
+		$customerdetailscomponent->setData($order, array(
+			"FirstName" => "Ed",
+			"Surname"	=> "Hillary",
+			"Email"		=> "ed@everest.net.xx"
+		));
+
+		$shippingaddresscomponent = $config->getComponentByType("ShippingAddressCheckoutComponent");
+		$shippingaddresscomponent->setData($order, $this->address1->toMap());
+
+		$billingaddresscomponent = $config->getComponentByType("BillingAddressCheckoutComponent");
+		$billingaddresscomponent->setData($order, $this->address2->toMap());
+
+		$paymentcomponent = $config->getComponentByType("PaymentCheckoutComponent");
+		$paymentcomponent->setData($order, array(
+			"PaymentMethod" => "Dummy"
+		));
+
+		$notescomponent = $config->getComponentByType("NotesCheckoutComponent");
+		$notescomponent->setData($order, array(
+			"Notes" => "Please bring coffee with goods"
+		));
+
+		$termscomponent = $config->getComponentByType("TermsCheckoutComponent");
+		$termscomponent->setData($order, array(
+			"ReadTermsAndConditions" => true
+		));
+
 		$components = $config->getComponents();
-		//assertions!
+		$this->assertContainsOnlyInstancesOf("CheckoutComponent_Namespaced", $components, "Name of ArrayList is CheckoutComponent_Namespaced");
+		$this->assertContains("CustomerDetailsCheckoutComponent", print_r($components, true));
+		$this->assertContains("ShippingAddressCheckoutComponent", print_r($components, true));
+		$this->assertContains("BillingAddressCheckoutComponent", print_r($components, true));
+		$this->assertContains("PaymentCheckoutComponent", print_r($components, true));
+		$this->assertContains("NotesCheckoutComponent", print_r($components, true));
+		$this->assertContains("TermsCheckoutComponent", print_r($components, true));
+		
 
 		$fields = $config->getFormFields();
-		//assertions!
 
+		$this->assertContains("CustomerDetailsCheckoutComponent_FirstName", print_r($fields, true), "Form Fields should contain a CustomerDetailsCheckoutComponent_FirstName field");
+		$this->assertContains("CustomerDetailsCheckoutComponent_Surname", print_r($fields, true), "Form Fields should contain a CustomerDetailsCheckoutComponent_Surname field");
+		$this->assertContains("CustomerDetailsCheckoutComponent_Email", print_r($fields, true), "Form Fields should contain a CustomerDetailsCheckoutComponent_Email field");
+		$this->assertContains("ShippingAddressCheckoutComponent_Country", print_r($fields, true), "Form Fields should contain a ShippingAddressCheckoutComponent_Country field");
+		$this->assertContains("ShippingAddressCheckoutComponent_Address", print_r($fields, true), "Form Fields should contain a ShippingAddressCheckoutComponent_Address field");
+		$this->assertContains("ShippingAddressCheckoutComponent_City", print_r($fields, true), "Form Fields should contain a ShippingAddressCheckoutComponent_City field");
+		$this->assertContains("ShippingAddressCheckoutComponent_State", print_r($fields, true), "Form Fields should contain a ShippingAddressCheckoutComponent_State field");
+		$this->assertContains("BillingAddressCheckoutComponent_Country", print_r($fields, true), "Form Fields should contain a BillingAddressCheckoutComponent_Country field");
+		$this->assertContains("BillingAddressCheckoutComponent_Address", print_r($fields, true), "Form Fields should contain a BillingAddressCheckoutComponent_Address field");
+		$this->assertContains("BillingAddressCheckoutComponent_City", print_r($fields, true), "Form Fields should contain a BillingAddressCheckoutComponent_City field");
+		$this->assertContains("BillingAddressCheckoutComponent_State", print_r($fields, true), "Form Fields should contain a BillingAddressCheckoutComponent_State field");
+		$this->assertNotContains("rubbish", print_r($fields, true), "Form Field should not include 'rubbish'");		
+
+		
 		$required = $config->getRequiredFields();
-		//assertions!
+		$requiredfields = array(
+			"CustomerDetailsCheckoutComponent_FirstName", 
+			"CustomerDetailsCheckoutComponent_Surname",
+			"CustomerDetailsCheckoutComponent_Email",
+			"ShippingAddressCheckoutComponent_Country",
+			"ShippingAddressCheckoutComponent_State",
+			"ShippingAddressCheckoutComponent_City",
+			"ShippingAddressCheckoutComponent_Address",
+			"BillingAddressCheckoutComponent_Country",
+			"BillingAddressCheckoutComponent_State",
+			"BillingAddressCheckoutComponent_City",
+			"BillingAddressCheckoutComponent_Address"
+		);
+		$this->assertSame($requiredfields, $required, "getRequiredFields function returns required fields from numerous components");
 
-		//$validateData = $config->validateData($data);
-		//assertions!
 
 		$data = $config->getData();
-		//assertions!
+
+		$this->assertEquals("Ed", $data["CustomerDetailsCheckoutComponent_FirstName"]);
+		$this->assertEquals("Hillary", $data["CustomerDetailsCheckoutComponent_Surname"]);
+		$this->assertEquals("ed@everest.net.xx", $data["CustomerDetailsCheckoutComponent_Email"]);
+		$this->assertEquals("AU", $data["ShippingAddressCheckoutComponent_Country"]);
+		$this->assertEquals("South Australia", $data["ShippingAddressCheckoutComponent_State"]);
+		$this->assertEquals("WEST BEACH", $data["ShippingAddressCheckoutComponent_City"]);
+		$this->assertEquals("5024", $data["ShippingAddressCheckoutComponent_PostalCode"]);
+		$this->assertEquals("201-203 BROADWAY AVE", $data["ShippingAddressCheckoutComponent_Address"]);
+		$this->assertEquals("U 235", $data["ShippingAddressCheckoutComponent_AddressLine2"]);
+		$this->assertEquals("NZ", $data["BillingAddressCheckoutComponent_Country"]);
+		$this->assertEquals("Ipsum", $data["BillingAddressCheckoutComponent_State"]);
+		$this->assertEquals("Lorem", $data["BillingAddressCheckoutComponent_City"]);
+		$this->assertEquals("1234", $data["BillingAddressCheckoutComponent_PostalCode"]);
+		$this->assertEquals("2 Foobar Ave", $data["BillingAddressCheckoutComponent_Address"]);
+		$this->assertEquals("U 235", $data["BillingAddressCheckoutComponent_AddressLine2"]);
+		$this->assertEquals("Dummy", $data["PaymentCheckoutComponent_PaymentMethod"]);
+		$this->assertEquals("Please bring coffee with goods", $data["NotesCheckoutComponent_Notes"]);
+
+
+		$validateData = $config->validateData($data);
+		$this->assertTrue($validateData, print_r($validateData, true), "Data validation must return true" . print_r($validateData, true));
 
 		$config->setData($data);
 		//assertions!
@@ -36,8 +129,72 @@ class CheckoutComponentTest extends SapphireTest {
 		//get data
 		$this->markTestIncomplete('Lots missing here');
 	}
+	
+
+	public function testSinglePageConfigForSingleCountrySiteWithReadonlyFieldsForCountry() {
+		// Set as a single country site
+		$this->loadFixture("shop/tests/fixtures/singlecountry.yml");  
+		$singlecountry = SiteConfig::current_site_config();  
+		$this->assertEquals("NZ", $singlecountry->getSingleCountry(), "Confirm that website is setup as a single country site");
+
+		$order = new Order();  //start a new order
+		$order->write();
+		$config = new SinglePageCheckoutComponentConfig($order);
+
+		$customerdetailscomponent = $config->getComponentByType("CustomerDetailsCheckoutComponent");
+		$customerdetailscomponent->setData($order, array(
+			"FirstName" => "John",
+			"Surname"	=> "Walker",
+			"Email"		=> "jw@onehundedsubfourminutemiles.nz"
+		));
+
+		$shippingaddresscomponent = $config->getComponentByType("ShippingAddressCheckoutComponent");
+		$shippingaddresscomponent->setData($order, $this->addressNoCountry->toMap());
+
+		$billingaddresscomponent = $config->getComponentByType("BillingAddressCheckoutComponent");
+		$billingaddresscomponent->setData($order, $this->addressNoCountry->toMap());
+
+		$paymentcomponent = $config->getComponentByType("PaymentCheckoutComponent");
+		$paymentcomponent->setData($order, array(
+			"PaymentMethod" => "Dummy"
+		));
+	
+
+		$fields = $config->getFormFields();
+		$shippingaddressfield = $fields->fieldByName("ShippingAddressCheckoutComponent_Country_readonly");
+		$billingaddressfield = $fields->fieldByName("BillingAddressCheckoutComponent_Country_readonly");
+
+		$this->assertContains("New Zealand", $shippingaddressfield->Value(), "The value of the Shipping Country readonly field is 'New Zealand'");
+		$this->assertContains("New Zealand", $billingaddressfield->Value(), "The value of the Billing Country readonly field is 'New Zealand'");
+		$this->assertTrue($shippingaddressfield->isReadonly(), "The Shipping Address Country field is readonly");
+		$this->assertTrue($shippingaddressfield->isReadonly(), "The Billing Address Country field is readonly");
+
+		
+		$required = $config->getRequiredFields();
+		$requiredfieldswithCountryAbsent = array(
+			"CustomerDetailsCheckoutComponent_FirstName", 
+			"CustomerDetailsCheckoutComponent_Surname",
+			"CustomerDetailsCheckoutComponent_Email",
+			"ShippingAddressCheckoutComponent_State",
+			"ShippingAddressCheckoutComponent_City",
+			"ShippingAddressCheckoutComponent_Address",
+			"BillingAddressCheckoutComponent_State",
+			"BillingAddressCheckoutComponent_City",
+			"BillingAddressCheckoutComponent_Address"
+		);
+		$this->assertSame($requiredfieldswithCountryAbsent, $required, "getRequiredFields function returns required fields from numerous components except for the Country fields (no need to validate readonly fields)");
 
 
-	//test namespaced config
+		$data = $config->getData();
+		$this->assertEquals("NZ", $data["ShippingAddressCheckoutComponent_Country"]);
+		$this->assertEquals("NZ", $data["BillingAddressCheckoutComponent_Country"]);
+
+
+		$validateData = $config->validateData($data);
+		$this->assertTrue($validateData, print_r($validateData, true), "Data validation must return true.  Note: should not be testing a country field here as validation of a readonly field is not necessary" . print_r($validateData, true));
+
+		$config->setData($data);
+
+	}
 
 }

--- a/tests/checkout/CheckoutFormTest.php
+++ b/tests/checkout/CheckoutFormTest.php
@@ -48,7 +48,7 @@ class CheckoutFormTest extends SapphireTest{
 		$form->loadDataFrom($data, true);
 		$valid = $form->validate();
 		$errors = $form->getValidator()->getErrors();
-		$this->assertTrue($valid);
+		$this->assertTrue($valid, print_r($errors, true));
 		$form->checkoutSubmit($data, $form);
 		$this->assertEquals("Jane", $order->FirstName);
 		$shipping = $order->ShippingAddress();
@@ -59,4 +59,54 @@ class CheckoutFormTest extends SapphireTest{
 		$this->markTestIncomplete('test components individually');
 	}
 
+
+	public function testCheckoutFormForSingleCountrySiteWithReadonlyFieldsForCountry() {
+
+		// Set as a single country site
+		$this->loadFixture("shop/tests/fixtures/singlecountry.yml");  
+		$singlecountry = SiteConfig::current_site_config();  
+		$this->assertEquals("NZ", $singlecountry->getSingleCountry(), "Confirm that website is setup as a single country site");
+
+		$order = ShoppingCart::curr();
+		$config = new SinglePageCheckoutComponentConfig($order);
+		$form = new CheckoutForm($this->checkoutcontroller, "OrderForm", $config);
+		// no country fields due to readonly field
+		$dataCountryAbsent = array(
+			"CustomerDetailsCheckoutComponent_FirstName" => "Jane",
+			"CustomerDetailsCheckoutComponent_Surname" => "Smith",
+			"CustomerDetailsCheckoutComponent_Email" => "janesmith@example.com",
+			"ShippingAddressCheckoutComponent_Address" => "1234 Green Lane",
+			"ShippingAddressCheckoutComponent_AddressLine2" => "Building 2",
+			"ShippingAddressCheckoutComponent_City" => "Bleasdfweorville",
+			"ShippingAddressCheckoutComponent_State" => "Trumpo",
+			"ShippingAddressCheckoutComponent_PostalCode" => "4123",
+			"ShippingAddressCheckoutComponent_Phone" => "032092277",
+			"BillingAddressCheckoutComponent_Address" => "1234 Green Lane",
+			"BillingAddressCheckoutComponent_AddressLine2" => "Building 2",
+			"BillingAddressCheckoutComponent_City" => "Bleasdfweorville",
+			"BillingAddressCheckoutComponent_State" => "Trumpo",
+			"BillingAddressCheckoutComponent_PostalCode" => "4123",
+			"BillingAddressCheckoutComponent_Phone" => "032092277",
+			"PaymentCheckoutComponent_PaymentMethod" => "Dummy",
+			"NotesCheckoutComponent_Notes" => "Leave it around the back",
+			"TermsCheckoutComponent_ReadTermsAndConditions" => "1"
+		);
+		$form->loadDataFrom($dataCountryAbsent, true);
+		$valid = $form->validate();
+		$errors = $form->getValidator()->getErrors();
+		$this->assertTrue($valid, print_r($errors, true));
+		$this->assertTrue($form->Fields()->fieldByName("ShippingAddressCheckoutComponent_Country_readonly")->isReadonly(), "Shipping Address Country field is readonly");
+		$this->assertTrue($form->Fields()->fieldByName("BillingAddressCheckoutComponent_Country_readonly")->isReadonly(), "Billing Address Country field is readonly");
+		$form->checkoutSubmit($dataCountryAbsent, $form);
+		
+		$shipping = $order->ShippingAddress();
+		$this->assertEquals("NZ", $shipping->Country);
+
+		$billing = $order->BillingAddress();
+		$this->assertEquals("NZ", $billing->Country);
+
+	}
+
 }
+
+

--- a/tests/checkout/OrderProcessorTest.php
+++ b/tests/checkout/OrderProcessorTest.php
@@ -63,6 +63,7 @@ class OrderProcessorTest extends SapphireTest {
 			'23 Small Street',
 			'North Beach',
 			'Springfield',
+			'Waikato',
 			'1234567',
 			'NZ',
 			'jbrown',
@@ -128,6 +129,7 @@ class OrderProcessorTest extends SapphireTest {
 			'100 Melrose Place',
 			null,
 			'Martinsonville',
+			'New Mexico',
 			null,
 			'EG',
 			'newpassword',
@@ -173,6 +175,7 @@ class OrderProcessorTest extends SapphireTest {
 			'4 The Strand',
 			null,
 			'Melbourne',
+			'Victoria',
 			null,
 			'AU'
 		);
@@ -204,7 +207,7 @@ class OrderProcessorTest extends SapphireTest {
 	 */
 	protected function placeOrder(
 		$firstname, $surname, $email,
-		$address1, $address2 = null, $city = null, $postcode = null, $country = null,
+		$address1, $address2 = null, $city = null, $state = null, $postcode = null, $country = null,
 		$password = null, $confirmpassword = null, $member = null
 	) {
 		$data = array(
@@ -212,7 +215,8 @@ class OrderProcessorTest extends SapphireTest {
 			'Surname' => $surname,
 			'Email' => $email,
 			'Address' => $address1,
-			'City' => $city
+			'City' => $city,
+			'State' => $state
 		);
 		if($address2) $data['AddressLine2'] = $address2;
 		if($postcode) $data['PostalCode'] = $postcode;

--- a/tests/fixtures/shop.yml
+++ b/tests/fixtures/shop.yml
@@ -68,11 +68,18 @@ Product:
 Address:
     foobar:
         Address: 12 Foo Street
-        Address2: Bar
+        AddressLine2: Bar
         City: Farmville
         State: New Sandwich
         Country: US
         #MemberID: can't be set, because it is below
+    pukekohe:
+        Address: 1 Queen Street
+        AddressLine2:
+        City: Pukekohe
+        State: Auckland
+        PostalCode: 2120
+        Phone: 5678 910
 
 Group:
     customers:

--- a/tests/fixtures/singlecountry.yml
+++ b/tests/fixtures/singlecountry.yml
@@ -1,0 +1,4 @@
+SiteConfig:
+  config:
+    Title: Shop Testing Website
+    AllowedCountries: NZ


### PR DESCRIPTION
The readonly field of Country_readonly (when operating in a single country) is not passed onto the saveaddress function.  Null is saved to the database.  Add a new textfield to the save address function.  

Is this the best solution?