### PR TITLE
Handle missing required values consistently in MatchObjectFilter.

### DIFF
--- a/code/cart/MatchObjectFilter.php
+++ b/code/cart/MatchObjectFilter.php
@@ -82,7 +82,7 @@ class MatchObjectFilter{
 					$value = $dbfield->prepValueForDB($this->data[$field]);	//product correct format for db values
 					$new[] = "\"$field\" = $value";
 				}else{
-					$new[] = "(\"{$field}\" = 0 OR \"$field\" IS NULL)";
+					$new[] = "\"$field\" IS NULL";
 				}
 			}else{
 				if(isset($this->data[$field])){

--- a/code/cart/MatchObjectFilter.php
+++ b/code/cart/MatchObjectFilter.php
@@ -77,10 +77,13 @@ class MatchObjectFilter{
 		foreach($fields as $field => $value){
 			$field = Convert::raw2sql($field);
 			if(array_key_exists($field, $db)){
-				$dbfield = $singleton->dbObject($field);
-				$value = (isset($this->data[$field])) ? $this->data[$field] : null;
-				$value = $dbfield->prepValueForDB($value);	//product correct format for db values
-				$new[] = "\"$field\" = $value";
+				if(isset($this->data[$field])){
+					$dbfield = $singleton->dbObject($field);
+					$value = $dbfield->prepValueForDB($this->data[$field]);	//product correct format for db values
+					$new[] = "\"$field\" = $value";
+				}else{
+					$new[] = "(\"{$field}\" = 0 OR \"$field\" IS NULL)";
+				}
 			}else{
 				if(isset($this->data[$field])){
 					$value = Convert::raw2sql($this->data[$field]);

--- a/tests/cart/MatchObjectFilterTest.php
+++ b/tests/cart/MatchObjectFilterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class MatchObjectFilterTest extends SapphireTest{
+
+	public function testRelationId() {
+		// Tests that an ID is automatically added to any relation fields in the DataObject's has_one.
+		$filter = new MatchObjectFilter('Product_OrderItem', array('ProductID' => 5), array('Product'));
+		$this->assertEquals($filter->getFilter(), array('"ProductID" = 5'), 'ID was added to filter');
+	}
+
+	public function testMissingValues() {
+		// Tests that missing values are included in the filter as IS NULL or = 0
+		// Missing value for a has_one relationship field.
+		$filter = new MatchObjectFilter('Product_OrderItem', array(), array('Product'));
+		$this->assertEquals($filter->getFilter(), array('("ProductID" = 0 OR "ProductID" IS NULL)'), 'missing ID value became IS NULL or = 0');
+		// Missing value for a db field.
+		$filter = new MatchObjectFilter('Product_OrderItem', array(), array('ProductVersion'));
+		$this->assertEquals($filter->getFilter(), array('("ProductVersion" = 0 OR "ProductVersion" IS NULL)'), 'missing DB value became IS NULL or = 0');
+	}
+
+}

--- a/tests/cart/MatchObjectFilterTest.php
+++ b/tests/cart/MatchObjectFilterTest.php
@@ -15,7 +15,7 @@ class MatchObjectFilterTest extends SapphireTest{
 		$this->assertEquals($filter->getFilter(), array('("ProductID" = 0 OR "ProductID" IS NULL)'), 'missing ID value became IS NULL or = 0');
 		// Missing value for a db field.
 		$filter = new MatchObjectFilter('Product_OrderItem', array(), array('ProductVersion'));
-		$this->assertEquals($filter->getFilter(), array('("ProductVersion" = 0 OR "ProductVersion" IS NULL)'), 'missing DB value became IS NULL or = 0');
+		$this->assertEquals($filter->getFilter(), array('"ProductVersion" IS NULL'), 'missing DB value became IS NULL or = 0');
 	}
 
 }


### PR DESCRIPTION
There is a discrepancy between how has_one and db fields are handled when required but no matching data is supplied.

The former results in a filter of `("FieldName" = 0 OR "FieldName" = NULL)` while the latter produces `"FieldName" = null`.