### PR TITLE
Add canView check to Order.

### DIFF
--- a/code/model/Order.php
+++ b/code/model/Order.php
@@ -341,6 +341,14 @@ class Order extends DataObject {
 	}
 
 	/**
+	 * Check if an order can be viewed.
+	 * @return boolean
+	 */
+	public function canView($member = null) {
+		return true;
+	}
+
+	/**
 	 * Check if an order can be edited.
 	 * @return boolean
 	 */


### PR DESCRIPTION
Without an implementation of canView, only administrators could view
order details.

Fixes #322 