### PR TITLE
Change Product Title label to "Title" (Rather than "Page Name")

### DIFF
--- a/code/product/Product.php
+++ b/code/product/Product.php
@@ -142,6 +142,15 @@ class Product extends Page implements Buyable {
 	}
 
 	/**
+	 * Fix grid field heading displaying "page name"
+	 */
+	public function fieldLabels($includerelations = true) {
+		$labels = parent::fieldLabels($includerelations);
+		$labels['Title'] = "Title";
+		return $labels;
+	}
+
+	/**
 	 * Helper function for generating list of categories to select from.
 	 * @return array categories
 	 */


### PR DESCRIPTION
Unfortunately cms SiteTree doesn't allow overriding labels that it has defined, so we need to kind of hack it in.