### PR TITLE
Improved display of product summary fields. Don't show an empty price…

### DIFF
--- a/code/model/fieldtypes/ShopCurrency.php
+++ b/code/model/fieldtypes/ShopCurrency.php
@@ -45,4 +45,12 @@ class ShopCurrency extends Currency {
 
 		return $val;
 	}
+
+	public function NiceOrEmpty() {
+		if($this->value != 0){
+			return $this->Nice();
+		}
+		return "";
+	}
+
 }

--- a/code/product/Product.php
+++ b/code/product/Product.php
@@ -53,21 +53,22 @@ class Product extends Page implements Buyable {
 	private static $summary_fields = array(
 		'InternalItemID',
 		'Title',
-		'BasePrice',
+		'BasePrice.NiceOrEmpty',
 		'canPurchase'
 	);
 
 	private static $searchable_fields = array(
 		'InternalItemID',
 		'Title' => array("title" => 'Title'),
-		'BasePrice',
 		'Featured'
 	);
 
 	private static $field_labels = array(
 		'InternalItemID' => 'SKU',
 		'Title' => 'Title',
-		'BasePrice' => 'Price'
+		'BasePrice' => 'Price',
+		'BasePrice.NiceOrEmpty' => 'Price',
+		'canPurchase' => 'Purchasable'
 	);
 
 	private static $singular_name = "Product";


### PR DESCRIPTION
This may be personal preference, but I think not displaying a prices in grid field can be clearer than displaying $0.00 . It becomes easier to distinguish which lines don't have a price.

In this PR I've added the `NiceOrEmpty` method to `ShopCurrency`, and made this the default way to list prices.

This PR also sets the `canPurchase` label as `Purchasable`.