### PR TITLE
Moved the CheckoutPage extistingValues toggle code

### DIFF
--- a/code/checkout/components/AddressBookCheckoutComponent.php
+++ b/code/checkout/components/AddressBookCheckoutComponent.php
@@ -10,7 +10,6 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 
 	protected $addtoaddressbook = true;
 
-
 	public function getFormFields(Order $order) {
 		$fields = parent::getFormFields($order);
 
@@ -20,7 +19,10 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 			$existingaddressfields->merge($fields);
 			// group under a composite field (invisible by default) so we
 			// easily know which fields to show/hide
-			$label = _t("AddressBookCheckkoutComponent.{$this->addresstype}Address", "{$this->addresstype} Address");
+			$label = _t(
+				"AddressBookCheckkoutComponent.{$this->addresstype}Address",
+				"{$this->addresstype} Address"
+			);
 
 			return new FieldList(
 				CompositeField::create($existingaddressfields)
@@ -44,7 +46,7 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 			$addressoptions['newaddress'] = _t("AddressBookCheckoutComponent.CREATENEWADDRESS", "Create new address");
 			$fieldtype = count($addressoptions) > 3 ? 'DropdownField' : 'OptionsetField';
 			$label = _t("AddressBookCheckoutComponent.Existing{$this->addresstype}Address", "Existing {$this->addresstype} Address");
-			
+
 			return new FieldList(
 				$fieldtype::create($this->addresstype."AddressID", $label,
 					$addressoptions,

--- a/javascript/CheckoutPage.js
+++ b/javascript/CheckoutPage.js
@@ -1,62 +1,71 @@
 (function($){
+
+	// Configuration defaults
+	if (typeof(window.ShopConfig) != 'object'){
+		window.ShopConfig = {};
+	}
+	if (typeof(window.ShopConfig.Checkout) != 'object'){
+		window.ShopConfig.Checkout = {};
+	}
+
+	window.ShopConfig.Checkout = $.extend({
+		showFieldAnimation: 'fadeIn',
+		hideFieldAnimation: 'fadeOut',
+	}, window.ShopConfig.Checkout);
+
+	var conf = window.ShopConfig.Checkout;
+
+	// Addressbook checkout component
+	// This handles a dropdown or radio buttons containing existing addresses or payment methods,
+	// with one of the options being "create a new ____". When that last option is selected, the
+	// other fields need to be shown, otherwise they need to be hidden.
+	function onExistingValueChange(){
+		$('.hasExistingValues').each(function(idx, container){
+			var $toggle = $('.existingValues select,.existingValues input:checked', container);
+			// visible if the value is not an ID (numeric)
+			var toggleState = isNaN(parseInt($toggle.val()));
+			var toggleMethod = toggleState ? conf.showFieldAnimation : conf.hideFieldAnimation;
+			var $toggleFields = $(container).find('.field').not('.existingValues');
+
+			// animate the fields
+			if ($toggleFields && $toggleFields.length > 0) {
+				if (typeof(toggleMethod) == 'object') {
+					$toggleFields.animate(toggleMethod, 'fast', 'swing');
+				} else {
+					$toggleFields[toggleMethod]('fast', 'swing');
+				}
+			}
+
+			// clear them out
+			$toggleFields.find('input, select, textarea')
+				.val('').prop('disabled', toggleState ? '' : 'disabled');
+		});
+	}
+
+	$('.existingValues select').on('change', onExistingValueChange);
+	$('.existingValues input[type=radio]').on('click', onExistingValueChange);
+
+	onExistingValueChange(); // handle initial state
+
+
 	$(document).ready(function() {
-
-		// Configuration defaults
-		if (typeof(window.ShopConfig) != 'object') window.ShopConfig = {};
-		if (typeof(window.ShopConfig.Checkout) != 'object') window.ShopConfig.Checkout = {};
-		window.ShopConfig.Checkout = $.extend({
-			showFieldAnimation: 'fadeIn',
-			hideFieldAnimation: 'fadeOut',
-		}, window.ShopConfig.Checkout);
-
 
 		// Payment checkout component (selecting a payment method)
 		var paymentInputs = $('#PaymentMethod input[type=radio]');
 		var methodFields = $('div.paymentfields');
-		
+
 		methodFields.hide();
-		
+
 		paymentInputs.each(function(e) {
 			if($(this).attr('checked') == true) {
 				$('#MethodFields_' + $(this).attr('value')).show();
 			}
 		});
-		
+
 		paymentInputs.click(function(e) {
 			methodFields.hide();
 			$('#MethodFields_' + $(this).attr('value')).show();
 		});
-
-
-		// Addressbook checkout component
-		// This handles a dropdown or radio buttons containing existing addresses or payment methods,
-		// with one of the options being "create a new ____". When that last option is selected, the
-		// other fields need to be shown, otherwise they need to be hidden.
-		function onExistingValueChange(){
-			$('.hasExistingValues').each(function(idx, container){
-				// visible if the value is not an ID (numeric)
-				var toggleState = isNaN(parseInt($('.existingValues select, .existingValues input:checked', container).val()));
-				var toggleMethod = toggleState ? ShopConfig.Checkout.showFieldAnimation : ShopConfig.Checkout.hideFieldAnimation;
-				var toggleFields = $(container).find('.field').not('.existingValues');
-
-				// animate the fields
-				if (toggleFields && toggleFields.length > 0) {
-					if (typeof(toggleMethod) == 'object') {
-						toggleFields.animate(toggleMethod, 'fast', 'swing');
-					} else {
-						toggleFields[toggleMethod]('fast', 'swing');
-					}
-				}
-
-				// clear them out
-				toggleFields.find('input, select, textarea').val('').prop('disabled', toggleState ? '' : 'disabled');
-			});
-		}
-
-		$('.existingValues select').on('change', onExistingValueChange);
-		$('.existingValues input[type=radio]').on('click', onExistingValueChange);
-
-		onExistingValueChange(); // handle initial state
 
 	});
 })(jQuery);


### PR DESCRIPTION
… outside of $(document).ready

This prevents fields disappearing after page has fully loaded, which could be seconds later if other javascript is loading/running (especially external scripts). I think we can assume the relevant DOM will be loaded since javascript is added to the bottom of the page.

I've also reorganised code to be  narrower, thus readable.