### PR TITLE
Updated docs for broken links

### DIFF
--- a/docs/en/01_Getting_Set_Up/01_Installation.md
+++ b/docs/en/01_Getting_Set_Up/01_Installation.md
@@ -9,4 +9,4 @@ composer require burnbright/silverstripe-shop "*"
 
 The `example_config.yml` file gives an exhaustive list of the possible configuration options within the shop module.
 
-See the [customisation](../Customisation) section of this documentation or more advanced customisations.
+See the [customisation](../02_Customisation) section of this documentation or more advanced customisations.

--- a/docs/en/01_Getting_Set_Up/03_Troubleshooting.md
+++ b/docs/en/01_Getting_Set_Up/03_Troubleshooting.md
@@ -20,7 +20,7 @@ If the form has been built well, it should have extension hooks that allow you t
 
 ## How do I customise the country field? - change country list, remove field completely, set default
 
-See the [customising docs](../Customisation).
+See the [customising docs](../02_Customisation).
 
 ## How do I set my site to use a different currency?
 
@@ -31,15 +31,15 @@ Payment::set_site_currency('CUR');
 
 ## I can't get payments to work? eg: PayPal, PaymentExpress, Other..
 
-see [payment](Payment)
+see [payment](06_Payment.md)
 
 ## How do I add shipping calculation to the checkout process? How do I customise fees for different locations / delivery zones?
 
-The default shop module provides a few shipping [modifiers](../How_It_Works/Order_Modifiers). You can also have one custom built for your needs.
+The default shop module provides a few shipping [modifiers](../03_How_It_Works/Order_Modifiers.md). You can also have one custom built for your needs.
 
 ## How do I use in a different language?
 
-Follow the [Silverstripe internationalisation guide](http://doc.silverstripe.org/framework/en/topics/i18n)
+Follow the [Silverstripe internationalisation guide](http://docs.silverstripe.org/en/developer_guides/i18n/)
 We welcome your contribution of language files.
 
 ## When are cart/order totals recalculated?

--- a/docs/en/01_Getting_Set_Up/04_Shipping.md
+++ b/docs/en/01_Getting_Set_Up/04_Shipping.md
@@ -1,6 +1,6 @@
 # Shipping
 
-Shipping calculations can be introduced to an order with an [order modifier](../How_It_Works/Order_Modifiers).
+Shipping calculations can be introduced to an order with an [order modifier](../03_How_It_Works/Order_Modifiers.md).
 
 Modifiers included with core code:
 

--- a/docs/en/01_Getting_Set_Up/05_Tax.md
+++ b/docs/en/01_Getting_Set_Up/05_Tax.md
@@ -1,7 +1,7 @@
 # Tax
 
 Tax calculation is often required by governments when selling items through an online shop.
-To enable tax calculations, you'll need to introduce an appropriate [order modifier](../How_It_Works/Order_Modifiers).
+To enable tax calculations, you'll need to introduce an appropriate [order modifier](../03_How_It_Works/Order_Modifiers.md).
 
 
 Modifiers included with core code:

--- a/docs/en/01_Getting_Set_Up/Tasks.md
+++ b/docs/en/01_Getting_Set_Up/Tasks.md
@@ -19,7 +19,7 @@ Adds members who have placed orders to the selected customer group (see the shop
 
 ## Automated Tasks
 
-These tasks are intended to be [run via cron jobs](http://doc.silverstripe.org/framework/en/topics/commandline#running-regular-tasks-with-cron).
+These tasks are intended to be [run via cron jobs](http://docs.silverstripe.org/en/developer_guides/cli/).
 
 ### Delete old carts
 
@@ -30,7 +30,7 @@ To run manually, in your browser visit:
 
 	[yoursiteurl.dom]/dev/tasks/CartCleanupTask
 
-To run automatically, trigger the following [sake script](http://doc.silverstripe.org/framework/en/topics/commandline) to run periodically on your sever:
+To run automatically, trigger the following [sake script](http://docs.silverstripe.org/en/developer_guides/cli/) to run periodically on your sever:
 
 	[yoursitepath]/framework/sake dev/tasks/CartCleanupTask
 

--- a/docs/en/01_Getting_Set_Up/index.md
+++ b/docs/en/01_Getting_Set_Up/index.md
@@ -1,29 +1,29 @@
-This tutorial explains start-to-finish how to set up an online shop with the SilverStripe shop module. If you are upgrading your shop, see [Upgrading](Getting_Set_Up/Upgrading).
+This tutorial explains start-to-finish how to set up an online shop with the SilverStripe shop module. If you are upgrading your shop, see [Upgrading](01_Getting_Set_Up/02_Upgrading.md).
 
 ## SilverStripe
 
-Follow the standard [SilverStripe installation guide](http://doc.silverstripe.org/framework/en/installation/) to get a SilverStripe website set up.
+Follow the standard [SilverStripe installation guide](http://docs.silverstripe.org/en/getting_started/installation/) to get a SilverStripe website set up.
 
 ## Install Shop
 
-[Install the shop module](Getting_Set_Up/Installation).
+[Install the shop module](01_Getting_Set_Up/01_Installation.md).
 
 ## Shipping and Tax
 
- * [Configure shipping](Getting_Set_Up/Shipping)
- * [Configure taxes](Getting_Set_Up/Tax)
+ * [Configure shipping](01_Getting_Set_Up/04_Shipping.md)
+ * [Configure taxes](01_Getting_Set_Up/05_Tax.md)
 
 ## Payment
 
-[Set up your payment provider](Getting_Set_Up/Payment), so customers can make online payments.
+[Set up your payment provider](01_Getting_Set_Up/06_Payment.md), so customers can make online payments.
 
 ## Automated Tasks
 
-Add some [automated tasks](Getting_Set_Up/Tasks) to handle some things automatically for you.
+Add some [automated tasks](01_Getting_Set_Up/Tasks.md) to handle some things automatically for you.
 
 ## Bulk Loading Products
 
-[Products can be bulk loaded](Getting_Set_Up/Bulk_Loading), saving time on larger websites.
+[Products can be bulk loaded](01_Getting_Set_Up/Bulk_Loading.md), saving time on larger websites.
 
 ## Testing / Development Environment
 Useful development tools are accessible via [yoursite]/dev/shop.

--- a/docs/en/02_Customisation/01_Recipes/Custom_Checkout.md
+++ b/docs/en/02_Customisation/01_Recipes/Custom_Checkout.md
@@ -22,4 +22,4 @@ A single step checkout is somewhat limited, because it requires the use of ajax 
 
 ## Multi Step Checkout
 
-See [Multi Step Checkout](Multi_Step_Checkout).
+See [Multi Step Checkout](Multi_Step_Checkout.md).

--- a/docs/en/02_Customisation/01_Recipes/Customising_Fields.md
+++ b/docs/en/02_Customisation/01_Recipes/Customising_Fields.md
@@ -4,7 +4,7 @@ You may want to store additional information for each customer.
 In a nutshell you need to update your DataModel, and any places where the 
 data is entered. This can generally be done by creating extensions.
 
-First read the [SilverStripe documentation about Extensions](http://doc.silverstripe.org/framework/en/reference/dataextension).
+First read the [SilverStripe documentation about Extensions](http://docs.silverstripe.org/en/developer_guides/model/extending_dataobjects/).
 
 ## Customer
 

--- a/docs/en/02_Customisation/01_Recipes/Multi_Step_Checkout.md
+++ b/docs/en/02_Customisation/01_Recipes/Multi_Step_Checkout.md
@@ -21,7 +21,7 @@ Next, optionally replace your `CheckoutPage.ss` template with one that uses step
  
 You may notice that the `SteppedCheckoutPage.ss` template contains statements like:
 
-```
+```html
 <% if IsFutureStep(contactdetails) %> ... <% end_if %>
 <% if IsCurrentStep(contactdetails) %> ... <% end_if %>
 <% if IsPastStep(contactdetails) %> ... <% end_if %>
@@ -31,7 +31,7 @@ These functions have been set up to enable a single page template to handle mult
 
 You can also define individual templates if you like, eg:
 
-```
+```html
 mysite/templates/Layout/CheckoutPage_contactdetails.ss
 mysite/templates/Layout/CheckoutPage_shippingaddress.ss
 mysite/templates/Layout/CheckoutPage_billingaddress.ss

--- a/docs/en/02_Customisation/01_Recipes/Multiple_Images_Product.md
+++ b/docs/en/02_Customisation/01_Recipes/Multiple_Images_Product.md
@@ -34,7 +34,7 @@ Product:
 
 `[mysite]/templates/Includes/AdditionalImages.ss`
 
-```
+```html
 <% if AdditionalImages %>
 	<% loop AdditionalImages %>
 		$Me

--- a/docs/en/02_Customisation/Contributing.md
+++ b/docs/en/02_Customisation/Contributing.md
@@ -15,7 +15,7 @@ If you would like to contribute code, please [fork this project](https://github.
 
 ## Development Guidelines
 
-We try to match [SilverStripe's guidelines](http://doc.silverstripe.org/sapphire/en/misc/contributing) 
+We try to match [SilverStripe's guidelines](http://docs.silverstripe.org/en/contributing/) 
 as closely as possible. In some ways our approach will differ, but it is a good idea to read their guidelines first.
 
 ## Workflow
@@ -46,4 +46,4 @@ This project political model used for this project is a [Benevolent Dictatorship
 
 See also:
 
- * [Development](Development)
+ * [Development](../03_How_It_Works/Development.md)

--- a/docs/en/02_Customisation/Submodules.md
+++ b/docs/en/02_Customisation/Submodules.md
@@ -6,4 +6,4 @@ See the README file for a list of some known submodules, or search in the releva
 
 [silverstripe addons](http://addons.silverstripe.org/add-ons?search=shop), or [packgist](https://packagist.org/search/?q=silverstripe%20shop), or [github](https://github.com/search?q=silverstripe+shop).
 
-If you are interested in contributing your own sub-module(s), see [contributing](Contributing) docs.
+If you are interested in contributing your own sub-module(s), see [contributing](Contributing.md) docs.

--- a/docs/en/02_Customisation/Testing.md
+++ b/docs/en/02_Customisation/Testing.md
@@ -3,8 +3,8 @@ Testing is highly important for maintaining a quality product.
 ## Unit Testing
 
 We insist that the shop module contains a suite of unit tests that are updated with any changes to the code. Sub-Modules should also have their own test suites.
-See the [framework testing documentation](http://doc.silverstripe.org/framework/en/topics/testing/index) for setup information etc.
-See also: [http://www.phpunit.de/manual/3.5/en/index.html](http://www.phpunit.de/manual/3.5/en/index.html)
+See the [framework testing documentation](http://docs.silverstripe.org/en/developer_guides/testing/) for setup information etc.
+See also: [https://phpunit.de/manual/3.7/en/](https://phpunit.de/manual/3.7/en/)
 
 To run all shop tests visit `yoursite/dev/tests/module/shop`. If you intend on doing lots of development, it might be a good idea to run tests from the command line.
 

--- a/docs/en/02_Customisation/index.md
+++ b/docs/en/02_Customisation/index.md
@@ -1,23 +1,23 @@
 It is most likely that you as a website developer/designer will want to customise the shop module to look and work as your client would like.
 
-There are a number of configuration options to be set in your _config files. See [Configuration](Customisation/Configuration)
+There are a number of configuration options to be set in your _config files. See [Configuration](02_Customisation/Configuration.md)
 
-[Recipes](Customisation/Recipes) contains a number of instructions for implementing specific features.
+[Recipes](02_Customisation/01_Recipes) contains a number of instructions for implementing specific features.
 
-See also: [Customisation/Submodules](Customisation/Submodules).
+See also: [Customisation/Submodules](02_Customisation/Submodules.md).
 
-See [Development](Customisation/Development) to understand the mission of this module.
+See [Development](02_Customisation/Development.md) to understand the mission of this module.
 
 ## Where to put your customisations?
 
 It may not be clear where to put your customisations of SilverStripe, and the shop module.
 Here are some tips:
 
- * Look for the same idea already implemented in a [shop submodule](Customisation/Submodules) or a [SilverStripe module](http://addons.silverstripe.org/).
+ * Look for the same idea already implemented in a [shop submodule](02_Customisation/Submodules.md) or a [SilverStripe module](http://addons.silverstripe.org/).
  You can save time if you find the work has already been done.
  * Create Extensions and [DataExtensions](http://doc.silverstripe.org/framework/en/reference/dataextension).
  This is the cleanest way of creating customisations. It may introduce slight overhead processing time however.
- * You should [create themes](http://doc.silverstripe.org/framework/en/topics/theme-development) in the themes directory, and split out into module directories, eg:
+ * You should [create themes](http://docs.silverstripe.org/en/developer_guides/templates/themes/) in the themes directory, and split out into module directories, eg:
  	* themes
  		* mytheme
  		* mytheme_shop
@@ -37,7 +37,7 @@ Hopefully you don't need to override core SilverStripe, or shop module code, but
  file: Object::useCustomClass("OldObject","NewObject");
  
  If these are bugfixes, or additional features that the core code would benefit from, please feel
- free to [contribute back](Customisation/Contributing).
+ free to [contribute back](02_Customisation/Contributing.md).
 
 ## Theming / Templates
 
@@ -48,9 +48,9 @@ summaries of past orders, and it is also used with the email template.
 To make your customisations you need to create your own corresponding version of the
 template/partial-template with the same name in your mysite/templates folder or the themes folder.
 
-More about developing themes [here](http://doc.silverstripe.org/framework/en/topics/theme-development).
+More about developing themes [here](http://docs.silverstripe.org/en/developer_guides/templates/themes/).
 Note: some templates are needed in multiple places to work.
 
 ## Modifiers
 
-Shipping and tax, etc see [Order Modifiers](How_It_Works/Order_Modifiers)
+Shipping and tax, etc see [Order Modifiers](03_How_It_Works/Order_Modifiers.md)

--- a/docs/en/03_How_It_Works/Architecture.md
+++ b/docs/en/03_How_It_Works/Architecture.md
@@ -2,7 +2,7 @@
 
 ## Basics to understand
 
-[ShoppingCart](Shopping_Cart) provides the API to add and remove items from the current order.
+[ShoppingCart](Shopping_Cart.md) provides the API to add and remove items from the current order.
 
 Products are pages, with some extra details, such as an image, and price.
 
@@ -27,7 +27,7 @@ Here is an overview of the model classes
   	* OrderItem
   	 * Product_OrderItem
    	 * ProductVariation_OrderItem
-   * OrderModifier - Shippping/Tax calculators etc... see [order modifiers](Order_Modifiers)
+   * OrderModifier - Shippping/Tax calculators etc... see [order modifiers](Order_Modifiers.md)
    * ProductVariation - variations in price/colour/shape etc for a product.
    
    * OrderStatusLog
@@ -52,7 +52,7 @@ Cart items are stored in the database. A new order is created when the first ite
 
 The checkout is a page type which includes an OrderForm, plus has the facility for displaying an order that has been placed. 
 
-Also see [core changes](Core_Changes).
+Also see [core changes](Core_Changes.md).
 
 ### Persisting order information
 

--- a/docs/en/03_How_It_Works/Core_Changes.md
+++ b/docs/en/03_How_It_Works/Core_Changes.md
@@ -1,7 +1,7 @@
 Here are the subclasses, and extensions of standard SilverStripe Framework components for the shop module.
 
  * `ShopCurrency` - provides ability to customise currency formatting.
- * `ProductBulkLoader` - extends CSVBulkLoader to provide shop-specific loading. See [Bulk Loading](BulkLoading) for more.
+ * `ProductBulkLoader` - extends CSVBulkLoader to provide shop-specific loading. See [Bulk Loading](../01_Getting_Set_Up/Bulk_Loading.md) for more.
  * `ShopDevelopmentAdmin` - extends DevelopmentAdmin so that we can call mysite/dev/shop
  * `OptionalConfirmedPasswordField` - requires entering a password twice to ensure it is correct.
  * `I18nDatetime` - provides I18n formating for dates.

--- a/docs/en/03_How_It_Works/Development.md
+++ b/docs/en/03_How_It_Works/Development.md
@@ -67,4 +67,4 @@ Change the system to handle small or large, simple or complex. Or at least make 
 
 See also:
 
- * [Release Process](../How_It_Works/Release_Process)
+ * [Release Process](../03_How_It_Works/Release_Process.md)

--- a/docs/en/03_How_It_Works/Member.md
+++ b/docs/en/03_How_It_Works/Member.md
@@ -5,4 +5,4 @@ If a member is logged in when they place an order, that order will be associated
 The way for a user to specify they don't want to become a member is by leaving the password fields blank on the checkout page.
 Usability could be further improved by adding a checkbox with the question "do you want to save your details?", which would show the password fields via ajax only when the user checks the box.
 
-![Membership Flow Chart](images\membership-flow-chart.jpg)
+![Membership Flow Chart](../images/membership-flow-chart.jpg)

--- a/docs/en/03_How_It_Works/Release_Process.md
+++ b/docs/en/03_How_It_Works/Release_Process.md
@@ -44,7 +44,7 @@ Upload to [github](https://github.com/burnbright/silverstripe-shop/downloads)
 
 * [website](http://ss-shop.org) info
 * [demo site](http://demo.ss-shop.org)
-* silverstripe [extensions page](http://www.silverstripe.org/shop-module/)
+* silverstripe [extensions page](http://addons.silverstripe.org/add-ons/burnbright/silverstripe-shop)
 
 ## Announce
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,32 +5,39 @@ Customisation is left to the developer, similar to how the SilverStripe CMS is c
 There is little in the way of online web-interface based configuration, tweaking and setup.
 This has been left for the store owner to collaborate with their developer. 
 
-## [Getting Set Up](Getting_Set_Up) < Start Here
+## [Getting Set Up](01_Getting_Set_Up) < Start Here
 
-* [Installation & Configuration](Getting_Set_Up/Installation) - requirements, instructions
-* [Upgrading](Getting_Set_Up/Upgrading)
-* [Troubleshooting](Getting_Set_Up/Troubleshooting)
-* [Payment](Getting_Set_Up/Payment)
-* [Bulk loading products from a CSV spreadsheet](Getting_Set_Up/Bulk_Loading)
-* [Shipping](Getting_Set_Up/Shipping) and [Tax](Getting_Set_Up/Tax) Calculation
+* [Installation & Configuration](01_Getting_Set_Up/01_Installation.md) - requirements, instructions
+* [Upgrading](01_Getting_Set_Up/02_Upgrading.md)
+* [Troubleshooting](01_Getting_Set_Up/03_Troubleshooting.md)
+* [Payment](01_Getting_Set_Up/06_Payment.md)
+* [Bulk loading products from a CSV spreadsheet](01_Getting_Set_Up/Bulk_Loading.md)
+* [Shipping](01_Getting_Set_Up/04_Shipping.md) and [Tax](01_Getting_Set_Up/05_Tax.md) Calculation
 
-## [Customisation](Customisation)
+## [Customisation](02_Customisation)
 
-* [Emails](Emails)
-* [Sub-modules - stock, discounts ...](Submodules)
-* [Templates and Theming](Templates_and_Themes)
-* [Recipes](Recipes) - how do build in various features.
+* [Configuration](02_Customisation/Configuration.md) via your mysite.config.yml file.
+* [Emails](02_Customisation/Emails.md)
+* [Sub-modules - stock, discounts ...](02_Customisation/Submodules.md)
+* [Templates and Theming](02_Customisation/Templates_and_Themes.md)
+* [Hooks](02_Customisation/Hooks.md)
+* [Recipes](02_Customisation/01_Recipes) - how do build in various features.
+* [Migrating To Silverstripe](02_Customisation/Migrating_To_SilverStripe.md)
+* [Contributing](02_Customisation/Contributing.md) - get involved with development.  
+ * [Testing](02_Customisation/Testing.md) - infrastructure / instructions
 
-* [Contributing](Contributing) - get involved with development.
- * [Testing](Testing) - infrastructure / instructions
 
 ## How it works
 
-* [Architecture](How_It_Works/Architecture)
- * [Modifiers](How_It_Works/OrderModifiers) - All about modifiers. What they are, and how they work.
- * [Core changes](How_It_Works/Core_Changes) that have been made to core SS - eg sitetree, etc
-* [Ordering Process](How_It_Works/OrderProcess) - catalogue selection, checkout, payment, account/fulfillment
-* [Development](How_It_Works/Development) - Mission/aim, Coding style/conventions, Release process
+* [Architecture](03_How_It_Works/Architecture.md)
+ * [Modifiers](03_How_It_Works/Order_Modifiers.md) - All about modifiers. What they are, and how they work.
+ * [Core changes](03_How_It_Works/Core_Changes.md) that have been made to core SS - eg sitetree, etc
+ * [Member](03_How_It_Works/Member.md)
+ * [Pricing](03_How_It_Works/Pricing.md) for complex pricing structures and [Product Variations](03_How_It_Works/Product_Variations.md) for predefined customisations.
+* [Ordering Process](03_How_It_Works/Order_Process.md) - catalogue selection, checkout, payment, account/fulfillment and [Order Modifiers](03_How_It_Works/Order_Modifiers.md) to customise calculations.
+* [Shopping Cart](03_How_It_Works/Shopping_Cart.md)
+* [Development](03_How_It_Works/Development.md) - Mission/aim, Coding style/conventions, Release process
+* [Glossary](03_How_It_Works/Glossary.md)
  
 ## External Links
 

--- a/docs_user/en/AddingEditingProducts.md
+++ b/docs_user/en/AddingEditingProducts.md
@@ -42,4 +42,4 @@ In the 'Content > Product Groups' tab you can specify secondary product groups t
 
 Another way to manage products is through the 'Products' section of the CMS. Here you can list products according to a number of search options, such as id,name, weight, price. 
 
-This is also where you can upload a spreadsheet of products. See [bulk loading products](BulkLoadingProducts)
+This is also where you can upload a spreadsheet of products. See [bulk loading products](BulkLoadingProducts.md)

--- a/docs_user/en/ProductVariations.md
+++ b/docs_user/en/ProductVariations.md
@@ -66,4 +66,4 @@ you can create variations for it.
 Creating and updating variations from a spreadsheet
 ---------------------------------------------------
 
-See [Bulk Loading Products](BulkLoadingProducts#ProductVariations).
+See [Bulk Loading Products](BulkLoadingProducts#ProductVariations.md).

--- a/docs_user/en/index.md
+++ b/docs_user/en/index.md
@@ -12,13 +12,13 @@ modified in any way.
 Contents
 --------
 
- * [Getting Started & Configuration](Configuration)
- * [Adding and editing products](AddingEditingProducts)
-  * [Images / Photos](AddingEditingProducts#ChoosingAnImage)
-  * [Creating and modifying products with a spreadsheet file](BulkLoadingProducts)
- * [Editing/understanding product variations](ProductVariations)
- * [Product categories](ProductCategories)
- * [Managing orders](OrderFulfilment)
+ * [Getting Started & Configuration](Configuration.md)
+ * [Adding and editing products](AddingEditingProducts.md)
+  * [Images / Photos](AddingEditingProducts.md#ChoosingAnImage)
+  * [Creating and modifying products with a spreadsheet file](BulkLoadingProducts.md)
+ * [Editing/understanding product variations](ProductVariations.md)
+ * [Product categories](ProductCategories.md)
+ * [Managing orders](OrderFulfilment.md)
   * Updating payment info
   * Cancelling an order
- * [Troubleshooting](Troubleshooting)
+ * [Troubleshooting](Troubleshooting.md)


### PR DESCRIPTION
Includes:
- some additional links in the Developer doc's index.md that were missing;
- shifted Development.md to 03_How_It_Works folder;
- added .md to file names to make links work on Github;
- updated silverstripe/PHPUnit links