### PR TITLE
Update en.yml

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -25,9 +25,9 @@ en:
     ADDRESSLINE2: 'Address Line 2 (optional)'
     CITY: 'City'
     STATE: 'State'
-    POSTALCODE:
+    POSTALCODE: 'Postal Code'
     ShippingAddress: 'Shipping Address '
-    BillingAddress: 'Billing Address''Postal Code'
+    BillingAddress: 'Billing Address'
     PHONE: 'Phone Number'
     ADDRESSHINT: 'street / thoroughfare number, name, and type or P.O. Box'
     ADDRESS2HINT: 'premises, building, apartment, unit, floor'


### PR DESCRIPTION
Postal Code string had a wrong positioning, so the label for BillingAddress in forms was "Billing Address Postal Code"