### PR TITLE
Added CheckoutStep_Summary component config extension hook.

### DIFF
--- a/code/checkout/CheckoutPage.php
+++ b/code/checkout/CheckoutPage.php
@@ -117,7 +117,7 @@ class CheckoutPage_Controller extends Page_Controller {
 		}
 
 		$config = new CheckoutComponentConfig(ShoppingCart::curr(), false);
-		$config->AddComponent(new OnsitePaymentCheckoutComponent());
+		$config->addComponent(new OnsitePaymentCheckoutComponent());
 
 		$form = PaymentForm::create($this, "PaymentForm", $config);
 		$form->setActions(new FieldList(
@@ -132,7 +132,7 @@ class CheckoutPage_Controller extends Page_Controller {
 	/**
 	 * Retrieves error messages for the latest payment (if existing).
 	 * This can originate e.g. from an earlier offsite gateway API response.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function PaymentErrorMessage() {

--- a/code/checkout/steps/CheckoutStep_Summary.php
+++ b/code/checkout/steps/CheckoutStep_Summary.php
@@ -20,6 +20,7 @@ class CheckoutStep_Summary extends CheckoutStep{
 		$config = new CheckoutComponentConfig(ShoppingCart::curr(), false);
 		$config->addComponent(new NotesCheckoutComponent());
 		$config->addComponent(new TermsCheckoutComponent());
+		$this->owner->extend('updateConfirmationComponentConfig', $config);
 
 		$form = new PaymentForm($this->owner, "ConfirmationForm", $config);
 		$form->setFailureLink($this->owner->Link('summary'));

--- a/code/model/Order.php
+++ b/code/model/Order.php
@@ -169,10 +169,11 @@ class Order extends DataObject {
 		}
 		$fields->addFieldsToTab('Root.Main', $parts);
 		$this->extend('updateCMSFields', $fields);
-		$payments = $fields->fieldByName("Root.Payments.Payments");
-		$fields->removeByName("Payments");
-		$fields->insertAfter($payments, "Content");
-		$payments->addExtraClass("order-payments");
+		if($payments = $fields->fieldByName("Root.Payments.Payments")){
+			$fields->removeByName("Payments");
+			$fields->insertAfter($payments, "Content");
+			$payments->addExtraClass("order-payments");
+		}
 
 		return $fields;
 	}


### PR DESCRIPTION
+Minor bugfix and tidy

Allow summary checkout component config to be updated in extensions./

Fix to prevent payment field manipulation in the case that such fields don't exist