### PR TITLE
Changed range value to be SellingPrice not Price

### DIFF
--- a/code/product/variations/ProductVariationsExtension.php
+++ b/code/product/variations/ProductVariationsExtension.php
@@ -46,7 +46,7 @@ class ProductVariationsExtension extends DataExtension {
 		if(!$variations->exists() || !$variations->Count()){
 			return null;
 		}
-		$prices = $variations->map('ID','Price')->toArray();
+		$prices = $variations->map('ID','SellingPrice')->toArray();
 		$pricedata = array(
 			'HasRange' => false,
 			'Max' => ShopCurrency::create(),


### PR DESCRIPTION
Changed the range value to be SellingPrice not Price on Product Variations.

If variations were extended via updateSellingPrice() then this function would of just used the standard Price. This will prevent that.