### PR TITLE
Include jquery javascript requirement in AddressBookCheckoutComponent

### DIFF
--- a/code/checkout/components/AddressBookCheckoutComponent.php
+++ b/code/checkout/components/AddressBookCheckoutComponent.php
@@ -14,7 +14,8 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 		$fields = parent::getFormFields($order);
 
 		if($existingaddressfields = $this->getExistingAddressFields()){
-			Requirements::javascript('shop/javascript/CheckoutPage.js');
+			Requirements::javascript(THIRDPARTY_DIR.'/jquery/jquery.min.js');
+			Requirements::javascript(SHOP_DIR.'/javascript/CheckoutPage.js');
 			// add the fields for a new address after the dropdown field
 			$existingaddressfields->merge($fields);
 			// group under a composite field (invisible by default) so we


### PR DESCRIPTION
Adds jquery as a requirement before the CheckoutPage.js requirement.

I'm not entirely sure this is the best approach, but I thought I'd at least bring it to your attention.

I'd personally rather include the js via a template, but I guess it depends how closely the js is tied to the php code.