### PR TITLE
Make all currently untranslated strings translatable.

### DIFF
--- a/code/account/AccountPage.php
+++ b/code/account/AccountPage.php
@@ -37,7 +37,7 @@ class AccountPage extends Page {
 		if($page = DataObject::get_one('AccountPage')) {
 			return $page;
 		}
-		user_error('No AccountPage was found. Please create one in the CMS!', E_USER_ERROR);
+		user_error(_t('AccountPage.NO_PAGE', 'No AccountPage was found. Please create one in the CMS!'), E_USER_ERROR);
 	}
 
 	/**

--- a/code/account/OrderActionsForm.php
+++ b/code/account/OrderActionsForm.php
@@ -100,7 +100,7 @@ class OrderActionsForm extends Form{
 					$form->sessionMessage($processor->getError(), 'bad');
 				}
 			}else{
-				$form->sessionMessage("Manual payment not allowed", 'bad');
+				$form->sessionMessage(_t('OrderActionsForm.MANUAL_NOT_ALLOWED', "Manual payment not allowed"), 'bad');
 			}
 
 			return $this->controller->redirectBack();

--- a/code/account/ShopAccountForm.php
+++ b/code/account/ShopAccountForm.php
@@ -86,7 +86,11 @@ class ShopAccountFormValidator extends RequiredFields{
 			if(DataObject::get_one('Member', "$field = '$uid' AND ID != ".$currentmember->ID)){
 				$this->validationError(
 					$field,
-					"\"$uid\" is already taken by another member. Try another.",
+					// re-use the message from checkout
+					sprintf(
+						_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
+						$field, $uid
+					),
 					"required"
 				);
 				$valid = false;

--- a/code/cart/CartEditField.php
+++ b/code/cart/CartEditField.php
@@ -50,7 +50,7 @@ class CartEditField extends FormField{
 	 * before it is rendered.
 	 * @param Closure $callback
 	 */
-	public function setEditableItemsCallback(Clousre $callback){
+	public function setEditableItemsCallback(Closure $callback){
 		$this->editableItemsCallback = $callback;
 	}
 
@@ -94,13 +94,13 @@ class CartEditField extends FormField{
 				if($variations->exists()){
 					$variationfield = DropdownField::create(
 						$name."[ProductVariationID]",
-						"Varaition",
+						_t('CartEditField.VARIATION', "Variation"),
 						$variations->map('ID', 'Title'),
 						$item->ProductVariationID
 					);
 				}
 			}
-			$remove = CheckboxField::create($name."[Remove]", "Remove");
+			$remove = CheckboxField::create($name."[Remove]", _t('CartEditField.REMOVE', "Remove"));
 			$editables->push($item->customise(array(
 				"QuantityField" => $quantity,
 				"VariationField" => $variationfield,

--- a/code/cart/CartForm.php
+++ b/code/cart/CartForm.php
@@ -15,7 +15,7 @@ class CartForm extends Form{
 				->setTemplate($template)
 		);
 		$actions = new FieldList(
-			FormAction::create("updatecart", "Update Cart")
+			FormAction::create("updatecart", _t('CartForm.UPDATE_CART', "Update Cart"))
 		);
 
 		parent::__construct($controller, $name, $fields, $actions);
@@ -60,10 +60,20 @@ class CartForm extends Form{
 			}
 		}
 		if($removecount){
-			$messages['remove'] = "Removed ".$removecount." items.";
+			$messages['remove'] = _t(
+				'CartForm.REMOVED_ITEMS',
+				"Removed {count} items.",
+				"count is the amount that was removed",
+				array('count' => $removecount)
+			);
 		}
 		if($updatecount){
-			$messages['updatecount'] = "Updated ".$updatecount." items.";
+			$messages['updatecount'] = _t(
+				'CartForm.UPDATED_ITEMS',
+				"Updated {count} items.",
+				"count is the amount that was updated",
+				array('count' => $updatecount)
+			);
 		}
 		if(count($messages)){
 			$form->sessionMessage(implode(" ", $messages), "good");

--- a/code/cart/CartPage.php
+++ b/code/cart/CartPage.php
@@ -31,14 +31,14 @@ class CartPage extends Page{
 		$fields = parent::getCMSFields();
 		if($checkouts = CheckoutPage::get()) {
 			$fields->addFieldToTab('Root.Links',
-				DropdownField::create('CheckoutPageID', 'Checkout Page',
+				DropdownField::create('CheckoutPageID', _t('CartPage.has_one_CheckoutPage', 'Checkout Page'),
 					$checkouts->map("ID", "Title")
 				)
 			);
 		}
 		if($pgroups = ProductCategory::get()) {
 			$fields->addFieldToTab('Root.Links',
-				DropdownField::create('ContinuePageID', 'Continue Product Group Page',
+				DropdownField::create('ContinuePageID', _t('CartPage.has_one_ContinuePage', 'Continue Product Group Page'),
 					$pgroups->map("ID", "Title")
 				)
 			);

--- a/code/cart/ShopQuantityField.php
+++ b/code/cart/ShopQuantityField.php
@@ -54,7 +54,11 @@ class ShopQuantityField extends ViewableData{
 		for($r=1; $r<= $this->max; $r++){
 			$qtyArray[$r] = $r;
 		}
-		return new NumericField($this->MainID() . '_Quantity', "Qty", $this->item->Quantity);
+		return new NumericField(
+			$this->MainID() . '_Quantity',
+			// this title currently doesn't show up in the front end, better assign a translation anyway.
+			_t('AddProductForm.Quantity', "Quantity"),
+			$this->item->Quantity);
 	}
 
 	public function MainID() {
@@ -106,8 +110,11 @@ class DropdownShopQuantityField extends ShopQuantityField{
 		for($r=1; $r<= $this->max; $r++){
 			$qtyArray[$r] = $r;
 		}
-		return new DropdownField($this->MainID() . '_Quantity', "Qty", $qtyArray, ($this->item->Quantity)
-			? $this->item->Quantity : "");
+		return new DropdownField(
+			$this->MainID() . '_Quantity',
+			// this title currently doesn't show up in the front end, better assign a translation anyway.
+			_t('AddProductForm.Quantity', "Quantity"),
+			$qtyArray, ($this->item->Quantity) ? $this->item->Quantity : "");
 	}
 
 }

--- a/code/checkout/CheckoutFieldFactory.php
+++ b/code/checkout/CheckoutFieldFactory.php
@@ -73,7 +73,7 @@ class CheckoutFieldFactory{
 		//TODO: only get one field if there is no option
 		return new OptionsetField(
 			'PaymentMethod',
-			_t("Checkout", "Payment Type"),
+			_t('CheckoutField.PAYMENT_TYPE', "Payment Type"),
 			GatewayInfo::get_supported_gateways(), array_keys(GatewayInfo::get_supported_gateways())
 		);
 	}
@@ -94,7 +94,7 @@ class CheckoutFieldFactory{
 
 		if(SiteConfig::current_site_config()->TermsPage()->exists()) {
 			$termsPage = SiteConfig::current_site_config()->TermsPage();
-			
+
 			$field = CheckboxField::create('ReadTermsAndConditions',
 				sprintf(_t('CheckoutField.TERMSANDCONDITIONS',
 					"I agree to the terms and conditions stated on the
@@ -105,7 +105,7 @@ class CheckoutFieldFactory{
 				)
 			);
 		}
-		
+
 		return $field;
 	}
 

--- a/code/checkout/CheckoutPage.php
+++ b/code/checkout/CheckoutPage.php
@@ -33,9 +33,10 @@ class CheckoutPage extends Page {
 	public function getCMSFields() {
 		$fields = parent::getCMSFields();
 		$fields->addFieldsToTab('Root.Main', array(
-			HtmlEditorField::create('PurchaseComplete', 'Purchase Complete', 4)
+			HtmlEditorField::create('PurchaseComplete', _t('CheckoutPage.db_PurchaseComplete', 'Purchase Complete'), 4)
 				->setDescription(
-					"This message is included in reciept email, after the customer submits the checkout"
+					_t('CheckoutPage.PURCHASE_COMPLETE_DESCRIPTION',
+						"This message is included in reciept email, after the customer submits the checkout")
 				)
 		), 'Metadata');
 		return $fields;
@@ -123,7 +124,7 @@ class CheckoutPage_Controller extends Page_Controller {
 		$form = PaymentForm::create($this, "PaymentForm", $config);
 
 		$form->setActions(new FieldList(
-			FormAction::create("submitpayment", "Submit Payment")
+			FormAction::create("submitpayment", _t('CheckoutPage.SUBMIT_PAYMENT', "Submit Payment"))
 		));
 
 		$form->setFailureLink($this->Link());

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -40,9 +40,9 @@ class OrderProcessor{
 	}
 
 	/**
-	 * URL to display success message to the user. 
+	 * URL to display success message to the user.
 	 * Happens after any potential offsite gateway redirects.
-	 * 
+	 *
 	 * @return String Relative URL
 	 */
 	public function getReturnUrl() {
@@ -79,14 +79,14 @@ class OrderProcessor{
 
 	/**
 	 * Map shop data to omnipay fields
-	 * 
+	 *
 	 * @param array $customData Usually user submitted data.
 	 * @return array
 	 */
 	protected function getGatewayData($customData) {
 		$shipping = $this->order->getShippingAddress();
 		$billing = $this->order->getBillingAddress();
-		
+
 		return array_merge(
 			$customData,
 			array(
@@ -118,7 +118,11 @@ class OrderProcessor{
 	 */
 	public function createPayment($gateway) {
 		if(!GatewayInfo::is_supported($gateway)) {
-			$this->error(_t("PaymentProcessor.INVALIDGATEWAY", "`$gateway` isn't a valid payment gateway."));
+			$this->error(_t(
+				"PaymentProcessor.INVALID_GATEWAY",
+				"`{gateway}` isn't a valid payment gateway.",
+				'gateway is the name of the payment gateway',
+				array('gateway' => $gateway)));
 			return false;
 		}
 		if(!$this->order->canPay(Member::currentUser())){
@@ -186,7 +190,7 @@ class OrderProcessor{
 			$this->error(_t("OrderProcessor.NOITEMS", "Order has no items."));
 			return false;
 		}
-		
+
 		return true;
 	}
 

--- a/code/checkout/components/AddressBookCheckoutComponent.php
+++ b/code/checkout/components/AddressBookCheckoutComponent.php
@@ -46,7 +46,18 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 			$addressoptions = $member->AddressBook()->sort('Created', 'DESC')->map('ID', 'toString')->toArray();
 			$addressoptions['newaddress'] = _t("AddressBookCheckoutComponent.CREATENEWADDRESS", "Create new address");
 			$fieldtype = count($addressoptions) > 3 ? 'DropdownField' : 'OptionsetField';
-			$label = _t("AddressBookCheckoutComponent.Existing{$this->addresstype}Address", "Existing {$this->addresstype} Address");
+
+			$label = '';
+			switch($this->addresstype){
+				case 'Billing':
+					$label = _t("AddressBookCheckoutComponent.EXISTING_BILLING_ADDRESS", "Existing Billing Address");
+					break;
+				case 'Shipping':
+					$label = _t("AddressBookCheckoutComponent.EXISTING_SHIPPING_ADDRESS", "Existing Shipping Address");
+					break;
+				default:
+					$label = _t("AddressBookCheckoutComponent.EXISTING_ADDRESS", "Existing Address");
+			}
 
 			return new FieldList(
 				$fieldtype::create($this->addresstype."AddressID", $label,

--- a/code/checkout/components/OnsitePaymentCheckoutComponent.php
+++ b/code/checkout/components/OnsitePaymentCheckoutComponent.php
@@ -29,7 +29,7 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 		$result = new ValidationResult();
 		//TODO: validate credit card data
 		if(!Helper::validateLuhn($data['number'])){
-			$result->error('Credit card is invalid');
+			$result->error(_t('OnsitePaymentCheckoutComponent.CREDIT_CARD_INVALID','Credit card is invalid'));
 			throw new ValidationException($result);
 		}
 	}

--- a/code/checkout/components/PaymentCheckoutComponent.php
+++ b/code/checkout/components/PaymentCheckoutComponent.php
@@ -35,12 +35,12 @@ class PaymentCheckoutComponent extends CheckoutComponent{
 	public function validateData(Order $order, array $data) {
 		$result = new ValidationResult();
 		if(!isset($data['PaymentMethod'])){
-			$result->error("Payment method not provided", "PaymentMethod");
+			$result->error(_t('PaymentCheckoutComponent.NO_PAYMENT_METHOD',"Payment method not provided"), "PaymentMethod");
 			throw new ValidationException($result);
 		}
 		$methods = GatewayInfo::get_supported_gateways();
 		if(!isset($methods[$data['PaymentMethod']])){
-			$result->error("Gateway not supported", "PaymentMethod");
+			$result->error(_t('PaymentCheckoutComponent.UNSUPPORTED_GATEWAY',"Gateway not supported"), "PaymentMethod");
 			throw new ValidationException($result);
 		}
 	}

--- a/code/checkout/steps/CheckoutStep_Address.php
+++ b/code/checkout/steps/CheckoutStep_Address.php
@@ -21,7 +21,7 @@ class CheckoutStep_Address extends CheckoutStep{
 	public function shippingaddress() {
 		$form = $this->ShippingAddressForm();
 		$form->Fields()->push(new CheckboxField(
-			"SeperateBilling", "Bill to a different address from this"
+			"SeperateBilling", _t('CheckoutStep_Address.SEPARATE_BILLING',"Bill to a different address from this")
 		));
 		$order = $this->shippingconfig()->getOrder();
 		if($order->BillingAddressID !== $order->ShippingAddressID){
@@ -34,7 +34,7 @@ class CheckoutStep_Address extends CheckoutStep{
 	public function ShippingAddressForm() {
 		$form = new CheckoutForm($this->owner, 'ShippingAddressForm', $this->shippingconfig());
 		$form->setActions(new FieldList(
-			new FormAction("setshippingaddress", "Continue")
+			new FormAction("setshippingaddress", _t('CheckoutStep.CONTINUE', "Continue"))
 		));
 		$this->owner->extend('updateShippingAddressForm', $form);
 
@@ -69,7 +69,7 @@ class CheckoutStep_Address extends CheckoutStep{
 	public function BillingAddressForm() {
 		$form = new CheckoutForm($this->owner, 'BillingAddressForm', $this->billingconfig());
 		$form->setActions(new FieldList(
-			new FormAction("setbillingaddress", "Continue")
+			new FormAction("setbillingaddress", _t('CheckoutStep.CONTINUE', "Continue"))
 		));
 		$this->owner->extend('updateBillingAddressForm', $form);
 

--- a/code/checkout/steps/CheckoutStep_ContactDetails.php
+++ b/code/checkout/steps/CheckoutStep_ContactDetails.php
@@ -34,7 +34,7 @@ class CheckoutStep_ContactDetails extends CheckoutStep{
 		$form = new CheckoutForm($this->owner, 'ContactDetailsForm', $config);
 		$form->setRedirectLink($this->NextStepLink());
 		$form->setActions(new FieldList(
-			new FormAction("checkoutSubmit", "Continue")
+			new FormAction("checkoutSubmit", _t('CheckoutStep.CONTINUE', "Continue"))
 		));
 		$this->owner->extend('updateContactDetailsForm', $form);
 

--- a/code/checkout/steps/CheckoutStep_Membership.php
+++ b/code/checkout/steps/CheckoutStep_Membership.php
@@ -35,8 +35,9 @@ class CheckoutStep_Membership extends CheckoutStep{
 	public function MembershipForm() {
 		$fields = new FieldList();
 		$actions = new FieldList(
-			new FormAction("createaccount", "Create an Account"),
-			new FormAction("guestcontinue", "Continue as Guest")
+			new FormAction("createaccount",
+				_t('CheckoutStep_Membership.CREATE_ACCOUNT', "Create an Account", 'This is an option presented to the user')),
+			new FormAction("guestcontinue", _t('CheckoutStep_Membership.CONTINUE_AS_GUEST', "Continue as Guest"))
 		);
 		$form = Form::create($this->owner, 'MembershipForm', $fields, $actions);
 		$this->owner->extend('updateMembershipForm', $form);
@@ -85,7 +86,8 @@ class CheckoutStep_Membership extends CheckoutStep{
 	public function CreateAccountForm() {
 		$form = new CheckoutForm($this->owner, "CreateAccountForm", $this->registerconfig());
 		$form->setActions(new FieldList(
-			new FormAction('docreateaccount', 'Create New Account')
+			new FormAction('docreateaccount',
+				_t('CheckoutStep_Membership.CREATE_NEW_ACCOUNT', 'Create New Account', 'This is an action (Button label)'))
 		));
 		$form->getValidator()->addRequiredField("Password");
 

--- a/code/checkout/steps/CheckoutStep_PaymentMethod.php
+++ b/code/checkout/steps/CheckoutStep_PaymentMethod.php
@@ -27,7 +27,7 @@ class CheckoutStep_PaymentMethod extends CheckoutStep{
 	public function PaymentMethodForm() {
 		$form = new CheckoutForm($this->owner, "PaymentMethodForm", $this->checkoutconfig());
 		$form->setActions(new FieldList(
-			FormAction::create("setpaymentmethod", "Continue")
+			FormAction::create("setpaymentmethod",  _t('CheckoutStep.CONTINUE', "Continue"))
 		));
 		$this->owner->extend('updatePaymentMethodForm', $form);
 

--- a/code/cms/ShopConfig.php
+++ b/code/cms/ShopConfig.php
@@ -36,13 +36,13 @@ class ShopConfig extends DataExtension {
 				UploadField::create('DefaultProductImage', _t('ShopConfig.DEFAULTIMAGE', 'Default Product Image'))
 			),
 			$countriestab = new Tab("Countries",
-				CheckboxSetField::create('AllowedCountries', 'Allowed Ordering and Shipping Countries',
+				CheckboxSetField::create('AllowedCountries', _t('ShopConfig.ALLOWED_COUNTRIES', 'Allowed Ordering and Shipping Countries'),
 					self::config()->iso_3166_country_codes
 				)
 			)
 		));
 		$fields->removeByName("CreateTopLevelGroups");
-		$countriestab->setTitle("Allowed Countries");
+		$countriestab->setTitle(_t('ShopConfig.ALLOWED_COUNTRIES_TAB_TITLE', "Allowed Countries"));
 	}
 
 	public static function get_base_currency() {

--- a/code/cms/dashboard/DashboardRecentMembersPanel.php
+++ b/code/cms/dashboard/DashboardRecentMembersPanel.php
@@ -28,7 +28,7 @@ if (class_exists('DashboardPanel')) {
 
 		public function getConfiguration() {
 			$fields = parent::getConfiguration();
-			$fields->push(TextField::create("Count", "Number of accounts to show"));
+			$fields->push(TextField::create("Count", _t('ShopDashboard.NUMBER_OF_ACCOUNTS', "Number of accounts to show")));
 			return $fields;
 		}
 

--- a/code/cms/dashboard/DashboardRecentOrdersChart.php
+++ b/code/cms/dashboard/DashboardRecentOrdersChart.php
@@ -26,7 +26,7 @@ if (class_exists('DashboardPanel')) {
 
 		public function getConfiguration() {
 			$fields = parent::getConfiguration();
-			$fields->push(TextField::create("Days", "Number of days to show"));
+			$fields->push(TextField::create("Days", _t('ShopDashboard.NUMBER_OF_DAYS', "Number of days to show")));
 			return $fields;
 		}
 

--- a/code/cms/dashboard/DashboardRecentOrdersPanel.php
+++ b/code/cms/dashboard/DashboardRecentOrdersPanel.php
@@ -28,7 +28,7 @@ if (class_exists('DashboardPanel')) {
 
 		public function getConfiguration() {
 			$fields = parent::getConfiguration();
-			$fields->push(TextField::create("Count", "Number of orders to show"));
+			$fields->push(TextField::create("Count", _t('ShopDashboard.NUMBER_OF_ORDERS', "Number of orders to show")));
 			return $fields;
 		}
 

--- a/code/model/Order.php
+++ b/code/model/Order.php
@@ -159,7 +159,7 @@ class Order extends DataObject {
 		$fs = "<div class=\"field\">";
 		$fe = "</div>";
 		$parts = array(
-			DropdownField::create("Status", _t("STATUS", "Status"), self::get_order_status_options()),
+			DropdownField::create("Status", _t('Order.db_Status', "Status"), self::get_order_status_options()),
 			LiteralField::create('Customer', $fs.$this->renderWith("OrderAdmin_Customer").$fe),
 			LiteralField::create('Addresses', $fs.$this->renderWith("OrderAdmin_Addresses").$fe),
 			LiteralField::create('Content', $fs.$this->renderWith("OrderAdmin_Content").$fe)
@@ -186,7 +186,7 @@ class Order extends DataObject {
 		$context = parent::getDefaultSearchContext();
 		$fields = $context->getFields();
 		$fields->push(
-			ListboxField::create("Status","Status")
+			ListboxField::create("Status",_t('Order.db_Status', "Status"))
 				->setSource(array_combine(
 					self::config()->placed_status,
 					self::config()->placed_status
@@ -194,9 +194,9 @@ class Order extends DataObject {
 				->setMultiple(true)
 		);
 		//add date range filtering
-		$fields->insertBefore(DateField::create("DateFrom", "Date from")
+		$fields->insertBefore(DateField::create("DateFrom", _t('Order.DATE_FROM', "Date from"))
 			->setConfig('showcalendar', true), 'Status');
-		$fields->insertBefore(DateField::create("DateTo", "Date to")
+		$fields->insertBefore(DateField::create("DateTo", _t('Order.DATE_TO', "Date to"))
 			->setConfig('showcalendar', true), 'Status');
 		//get the array, to maniplulate name, and fullname seperately
 		$filters = $context->getFilters();

--- a/code/model/ShopMember.php
+++ b/code/model/ShopMember.php
@@ -31,7 +31,7 @@ class ShopMember extends DataExtension {
 		$fields->removeByName("DefaultShippingAddressID");
 		$fields->removeByName("DefaultBillingAddressID");
 		$fields->addFieldToTab('Root.Main',
-			new DropdownField('Country', 'Country',
+			new DropdownField('Country', _t('Address.COUNTRY', 'Country'),
 				SiteConfig::current_site_config()->getCountriesList()
 			)
 		);

--- a/code/model/Zone.php
+++ b/code/model/Zone.php
@@ -59,7 +59,8 @@ class Zone extends DataObject{
 		$fields = parent::getCMSFields();
 		$fields->fieldByName("Root")->removeByName("Regions");
 		if($this->isInDB()){
-			$regionsTable = new GridField("Regions", "Regions", $this->Regions(), new GridFieldConfig_RelationEditor());
+			$regionsTable = new GridField("Regions",
+				_t('Zone.has_many_Regions', "Regions"), $this->Regions(), new GridFieldConfig_RelationEditor());
 			$fields->addFieldsToTab("Root.Main", $regionsTable);
 		}
 		return $fields;

--- a/code/product/AddProductForm.php
+++ b/code/product/AddProductForm.php
@@ -83,9 +83,9 @@ class AddProductForm extends Form {
 				$count++;
 			}
 
-			$fields->push(new DropdownField(_t('AddProductForm.Quantity', 'Quantity'),'Quantity', $values, 1));
+			$fields->push(new DropdownField('Quantity', _t('AddProductForm.Quantity', 'Quantity'), $values, 1));
 		} else {
-			$fields->push(new NumericField(_t('AddProductForm.Quantity', 'Quantity'), 'Quantity', 1));
+			$fields->push(new NumericField('Quantity', _t('AddProductForm.Quantity', 'Quantity'), 1));
 		}
 
 		return $fields;

--- a/code/product/variations/ProductAttributeType.php
+++ b/code/product/variations/ProductAttributeType.php
@@ -49,19 +49,21 @@ class ProductAttributeType extends DataObject{
 
 	public function getCMSFields(){
 		$fields = new FieldList(
-			TextField::create("Name"),
-			TextField::create("Label")
+			TextField::create("Name", _t('ProductAttributeType.db_Name', 'Name')),
+			TextField::create("Label", _t('ProductAttributeType.db_Label', 'Label'))
 		);
 		if($this->isInDB()){
 			$fields->push(GridField::create(
-				"Values","Values",$this->Values(),
+				"Values",
+				_t('ProductAttributeType.has_many_Values',"Values"),
+				$this->Values(),
 				GridFieldConfig_RecordEditor::create()
 			));
 		}else{
 			$fields->push(LiteralField::create("Values",
-				"<p class=\"message warning\">
-					Save first, then you can add values.
-				</p>"
+				'<p class="message warning">' .
+					_t('ProductAttributeType.SAVE_FIRST_MESSAGE', 'Save first, then you can add values.') .
+				'</p>'
 			));
 		}
 

--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -73,8 +73,8 @@ class ProductVariation extends DataObject implements Buyable {
 
 	public function getCMSFields() {
 		$fields = new FieldList(
-			TextField::create('InternalItemID','Product Code'),
-			TextField::create('Price')
+			TextField::create('InternalItemID', _t('Product.CODE', 'Product Code')),
+			TextField::create('Price', _t('Product.PRICE', 'Price'))
 		);
 		//add attributes dropdowns
 		$attributes = $this->Product()->VariationAttributeTypes();
@@ -87,20 +87,26 @@ class ProductVariation extends DataObject implements Buyable {
 					$fields->push($field);
 				}else{
 					$fields->push(LiteralField::create('novalues'.$attribute->Name,
-						"<p class=\"message warning\">".
-							$attribute->Name." has no values to choose from.
-							You can create them in the \"Products\" &#62;
-							\"Product Attribute Type\" section of the CMS.
-						</p>"
+						'<p class="message warning">'.
+							_t(
+								'ProductVariation.NO_ATTRIBUTE_VALUES_MESSAGE',
+								'{attribute} has no values to choose from. You can create them in the "Products" &#62; "Product Attribute Type" section of the CMS.',
+								'Warning that will be shown if an attribute doesn\'t have any values',
+								array('attribute' => $attribute->Name)
+							) .
+						'</p>'
 					));
 				}
 				//TODO: allow setting custom values here, rather than visiting the products section
 			}
 		}else{
 			$fields->push(LiteralField::create('savefirst',
-				"<p class=\"message warning\">".
-					"You can choose variation attributes after saving for the first time, if they exist.
-				</p>"
+				'<p class="message warning">'.
+					_t(
+						'ProductVariation.SAVE_FIRST_MESSAGE',
+						"You can choose variation attributes after saving for the first time, if they exist."
+					) .
+				'</p>'
 			));
 		}
 		$fields->push(

--- a/code/product/variations/ProductVariationsExtension.php
+++ b/code/product/variations/ProductVariationsExtension.php
@@ -20,20 +20,24 @@ class ProductVariationsExtension extends DataExtension {
 	 */
 	public function updateCMSFields(FieldList $fields) {
 		$fields->addFieldsToTab('Root.Variations',array(
-			ListboxField::create("VariationAttributeTypes", "Attributes",
+			ListboxField::create("VariationAttributeTypes", _t('ProductVariationsExtension.ATTRIBUTES', "Attributes"),
 				ProductAttributeType::get()->map("ID", "Title")->toArray()
 			)->setMultiple(true)
-			->setDescription("These are fields to indicate the way(s) each variation varies. Once selected, they can be edited on each variation."),
-			GridField::create("Variations","Variations",
+			->setDescription(_t(
+				'ProductVariationsExtension.ATTRIBUTES_DESCRIPTION',
+				"These are fields to indicate the way(s) each variation varies. Once selected, they can be edited on each variation."
+			)),
+			GridField::create("Variations", _t('ProductVariationsExtension.VARIATIONS', "Variations"),
 				$this->owner->Variations(),
 				GridFieldConfig_RecordEditor::create()
 			)
 		));
 		if($this->owner->Variations()->exists()) {
 			$fields->addFieldToTab('Root.Pricing',
-				LabelField::create('variationspriceinstructinos','
-					Price - Because you have one or more variations, the price can be set in the "Variations" tab.'
-				)
+				LabelField::create('variationspriceinstructinos', _t(
+					'ProductVariationsExtension.VARIATIONS_INSTRUCTIONS',
+					"Price - Because you have one or more variations, the price can be set in the \"Variations\" tab."
+				))
 			);
 			$fields->removeFieldFromTab('Root.Pricing','BasePrice');
 			$fields->removeFieldFromTab('Root.Pricing','CostPrice');

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -17,13 +17,18 @@ class VariationForm extends AddProductForm {
 
 		foreach($attributes as $attribute){
 			$farray[] = $attribute->getDropDownField(
-				"Choose $attribute->Label ...", 
+				_t(
+					'VariationForm.CHOOSE_ATTRIBUTE',
+					"Choose {attribute} …",
+					'',
+					array('attribute' => $attribute->Label)
+				),
 				$product->possibleValuesForAttributeType($attribute)
 			);
-			
+
 			$requiredfields[] = "ProductAttributes[$attribute->ID]";
 		}
-		
+
 		$fields = new FieldList($farray);
 
 		if(self::$include_json) {
@@ -53,7 +58,7 @@ class VariationForm extends AddProductForm {
 	}
 
 	/**
-	 * Adds a given product to the cart. If a hidden field is passed 
+	 * Adds a given product to the cart. If a hidden field is passed
 	 * (ValidateVariant) then simply a validation of the user including that
 	 * product is done and the users cart isn't actually changed.
 	 *
@@ -63,7 +68,7 @@ class VariationForm extends AddProductForm {
 		if($variation = $this->getBuyable($data)) {
 			$quantity = (isset($data['Quantity']) && is_numeric($data['Quantity'])) ? (int) $data['Quantity'] : 1;
 			$cart = ShoppingCart::singleton();
-			
+
 			// if we are in just doing a validation step then check
 			if($this->request->requestVar('ValidateVariant')) {
 				$message = '';
@@ -91,7 +96,7 @@ class VariationForm extends AddProductForm {
 
 			if($cart->add($variation, $quantity)) {
 				$form->sessionMessage(
-					"Successfully added to cart.",
+					_t('ShoppingCart.ITEMADD', "Item has been added successfully."),
 					"good"
 				);
 			} else {
@@ -99,7 +104,10 @@ class VariationForm extends AddProductForm {
 			}
 		} else {
 			$variation = null;
-			$form->sessionMessage("That variation is not available, sorry.","bad"); //validation fail
+			$form->sessionMessage(
+				_t('VariationForm.VARIATION_NOT_AVAILABLE', "That variation is not available, sorry."),
+				"bad"
+			); //validation fail
 		}
 
 		$this->extend('updateVariationAddToCart', $form, $variation);

--- a/code/product/variations/VariationFormValidator.php
+++ b/code/product/variations/VariationFormValidator.php
@@ -11,7 +11,8 @@ class VariationFormValidator extends RequiredFields {
 
 		if($valid && !$this->form->getBuyable($_POST)) {
 			$this->validationError(
-				"","This product is not available with the selected options."
+				"",
+				_t('VariationForm.PRODUCT_NOT_AVAILABLE', "This product is not available with the selected options.")
 			);
 
 			$valid = false;

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -21,6 +21,7 @@ de:
     PLURALNAME: Kundenkonto
     SINGULARNAME: Kundenkonto
     Title: "Frühere Bestellungen"
+    NO_PAGE: "Es wurde keine Kundenkonto-Seite gefunden. Bitte erstellen Sie eine im CMS!"
   AccountPage.ss:
     COMPLETED: "Abgeschlossene Bestellungen"
     HISTORY: "Ihr Bestellhistorie"
@@ -60,7 +61,7 @@ de:
     CITYHINT: ""
     COUNTRY: Land
     PHONE: Telefonnummer
-    PLURALNAME: Adresse
+    PLURALNAME: Adressen
     POSTALCODE: Postleitzahl
     SINGULARNAME: Adresse
     STATE: "Staat"
@@ -83,6 +84,9 @@ de:
     has_one_Member: Kunde
   AddressBookCheckoutComponent:
     CREATENEWADDRESS: "Adresse ändern"
+    EXISTING_BILLING_ADDRESS: "Vorhandene Rechnungsadresse"
+    EXISTING_SHIPPING_ADDRESS: "Vorhandene Lieferadresse"
+    EXISTING_ADDRESS: "Vorhandene Adresse"
   Cart.ss:
     ADDONE: "Hinzufügen eine oder mehr von  \"%s\"  in den Warenkorb"
     CheckoutClick: "Hier klicken um auszuchecken"
@@ -131,6 +135,7 @@ de:
     PASSWORD: Passwort
     SURNAME: Nachname
     TERMSANDCONDITIONS: "Ich habe die <a href=\"AGB\" title=\"Allgemeine Geschäftsbedingungen anzeigen\">Allgemeine Geschäftsbedingungen</a> und die <a href=/widerrufsbelehrung-formular>Wiederufsbelehrung</a> gelesen und akzeptiert."
+    PAYMENT_TYPE: Zahlungsart
   CheckoutFields:
     PAYMENTTYPE: Zahlungsart
   CheckoutForm:
@@ -143,6 +148,8 @@ de:
     SINGULARNAME: Kassenseite
     TITLE: Kasse
     db_PurchaseComplete: "Bestellung abgeschlossen"
+    PURCHASE_COMPLETE_DESCRIPTION: "Diese Meldung wird dem Kunden im Bestätigungs-E-Mail gesendet, nachdem der Bestellvorgang abgeschlossen wurde."
+    SUBMIT_PAYMENT: "Bezahlen"
   CheckoutPage.ss:
     CARTEMPTY: "Ihr Warenkorb ist leer."
     CHECKOUT: Kasse
@@ -214,6 +221,7 @@ de:
     OUTSTANDING: "Ausstehend: %s"
     PAYMENTMETHOD: Zahlungsart
     PAYORDER: "Restbetrag bezahlen"
+    MANUAL_NOT_ALLOWED: "Bezahlung gegen Rechnung nicht erlaubt."
   OrderAdmin_Addresses.ss:
     ADDRESS: Adresse
     BILLTO: "Rechnung an"
@@ -332,6 +340,7 @@ de:
     MENUTITLE: Bestellungen
   Payment: ~
   PaymentProcessor:
+    INVALID_GATEWAY: "`{gateway}` ist kein gültiges Bezahl-Gateway."
     CANTPAY: "Diese Bestellung kann nicht bezahlt werden."
   PickupShippingModifier:
     PLURALNAME: Modifikatoren
@@ -342,6 +351,7 @@ de:
     CATEGORY: Category
     CATEGORYDESCRIPTION: "Dies ist die übergeordnete Seite oder Standardkategorie."
     CODE: Artikelnummer
+    CODE_SHORT: "Art. Nr."
     COSTPRICE: Kostenpreis
     COSTPRICEDESC: "Großhandelspreis ohne Preisaufschlag."
     DEPTH: "Tiefe. (%s)"
@@ -357,6 +367,7 @@ de:
     SINGULARNAME: Produkt
     WEIGHT: "Gewicht (%s)"
     WIDTH: "Breite (%s)"
+    NO_IMAGE: "kein Bild"
     db_AllowPurchase: "Kaufen erlauben"
     db_BasePrice: Basispreis
     db_CostPrice: Kostenpreis
@@ -392,6 +403,7 @@ de:
   ProductAttributeType:
     PLURALNAME: Eigenschaften
     SINGULARNAME: Eigenschaft
+    SAVE_FIRST_MESSAGE: "Werte können nach erstmaligem Speichern erfasst werden."
     belongs_many_many_Product: Produkt
     db_Label: Label
     db_Name: Name
@@ -432,6 +444,9 @@ de:
     NEXT: Nächste
     PAGE: Seite
     PREVIOUS: Vorherige
+    VIEW_PREVIOUS: "Zur vorherigen Seite"
+    VIEW_NEXT: "Zur nächsten Seite"
+    VIEW_PAGE: "Zeige Seite {pageNum}"
   ProductGroupItem.ss:
     ADD: "\"%s\" zum Warenkorb hinzufügen"
     ADDLINK: "In den Warenkorb"
@@ -450,11 +465,18 @@ de:
     has_one_Image: Bild
     has_one_Product: Produkt
     many_many_AttributeValues: Eigenschaften
+    NO_ATTRIBUTE_VALUES_MESSAGE: "Es gibt keine Werte für {attribute}. Diese können im 'Katalog' erstellt werden."
+    SAVE_FIRST_MESSAGE: "Attribute können erst nach dem ersten Speichern ausgewählt werden (gesetzt der Fall, sie existieren)."
+  ProductVariationsExtension:
+    ATTRIBUTES: "Attribute"
+    ATTRIBUTES_DESCRIPTION: "Diese Felder definieren die Attribute welche die Variationen ausmachen. Sobald sie ausgewählt wurden, können sie in jeder Variation erfasst werden."
+    VARIATIONS: "Variationen"
+    VARIATIONS_INSTRUCTIONS: "Da mehrere Variationen vorhanden sind, muss der Preis bei den Variationen erfasst werden."
   ProductVariation_OrderItem:
     PLURALNAME: Artikel
     SINGULARNAME: Artikel
     db_ProductVariationVersion: "Produkt Variations Version"
-    has_one_ProductVariation: "ProduKt Variation"
+    has_one_ProductVariation: "Produkt Variation"
   Product_OrderItem:
     PLURALNAME: Artikel
     SINGULARNAME: Artikel
@@ -479,6 +501,8 @@ de:
     CUSTOMERGROUP: "Gruppe, um neue Kunden zu ergänzen"
     DEFAULTIMAGE: "Standard Produktbild"
     TERMSPAGE: "Allgemeine Geschäftsbedingungen"
+    ALLOWED_COUNTRIES: "Länder für Bestellungen und Lieferungen"
+    ALLOWED_COUNTRIES_TAB_TITLE: "Erlaubte Länder"
   ShopCurrency:
     FREE: "<span class=\"frei\">FREI</span>"
   ShopDashboard:
@@ -488,6 +512,13 @@ de:
     RecentAccountsDescription: "Die letzten Anmeldungen in Kundenkonten anzeigen"
     RecentOrdersChart: "Bestellhistorie sortieren"
     RecentOrdersChartDescription: "Zeigt die letzten Bestellungen in einem Diagramm"
+    NUMBER_OF_ACCOUNTS: "Anzahl anzuzeigender Benutzer"
+    NUMBER_OF_DAYS: "Anzahl anzuzeigender Tage"
+    NUMBER_OF_ORDERS: "Anzahl anzuzeigender Bestellungen"
+    # These should probably be moved into a more generic category, since they can be used in a lot of places
+    EDIT: "Bearbeiten"
+    CUSTOMER: "Kunde"
+    DATE: "Datum"
   ShopDatabaseAdmin.ss:
     BUILDTASKS: "Aufgaben anlegen"
     CARTCLEANUP: "Alte Warenkörbe bereinigen"
@@ -536,6 +567,11 @@ de:
     NOORDER: "Keine aktuelle Bestellung."
     PRODUCTNOTFOUND: "Produkt nich gefunden."
     QUANTITYSET: "Die Menge wurde eingegeben."
+    # Pretty generic translation, could be moved to a more generic category
+    CHANGE: "Wechsel"
+    ITEMS_IN_CART_PLURAL: "In Ihrem Warenkorb befinden sich <a href=\"{link}\">{quantity} Artikel</a>."
+    ITEMS_IN_CART_SINGULAR: "In Ihrem Warenkorb befindet sich <a href=\"{link}\">1 Artikel</a>."
+    CHECKOUT: "Zur Kasse"
   SideCart.ss:
     HEADLINE: Warenkorb
     NOITEMS: "Es befinden sich keine Produkte im Warenkorb"
@@ -579,3 +615,40 @@ de:
   shop:
     Checkout: Zahlungsart
     STATUS: Status
+  CartEditField:
+    REMOVE: "Entfernen"
+    VARIATION: "Variationen"
+  CartForm:
+    UPDATE_CART: "Warenkorb aktualisieren"
+    REMOVED_ITEMS: "{count} Artikel entfernt"
+    UPDATED_ITEMS: "{count} Artikel aktualisiert."
+  OnsitePaymentCheckoutComponent:
+    CREDIT_CARD_INVALID: "Kreditkarte ist ungültig"
+  PaymentCheckoutComponent:
+    NO_PAYMENT_METHOD: "Bezahlmethode wurde nicht angegeben"
+    UNSUPPORTED_GATEWAY: "Bezahl-Gateway wird nicht unterstützt"
+  CheckoutStep:
+    # These should probably go somewhere else, as they are pretty generic.
+    CONTINUE: "Weiter"
+    SHIPPING: "Lieferung"
+    SUMMARY: "Zusammenfassung"
+    GRAND_TOTAL: "Gesamtbetrag"
+  CheckoutStep_Address:
+    SUPPLY_CONTACT_INFO: "Bitte geben Sie ihre Kontaktdaten an"
+    SEPARATE_BILLING: "Andere Rechnungsadresse angeben"
+    ENTER_SHIPPING_ADDRESS: "Bitte geben sie ihre gewünschte Lieferadresse ein."
+    BILL_TO: "Rechnung an:"
+    SHIP_TO: "Lieferung an:"
+  CheckoutStep_Membership:
+    CONTINUE_AS_GUEST: "Weiter als Gast"
+    # This is an option presented to the user
+    CREATE_ACCOUNT: "Neues Konto erstellen"
+    # This is an action (Button label)
+    CREATE_NEW_ACCOUNT: 'Konto erstellen'
+  VariationForm:
+    CHOOSE_ATTRIBUTE: "Wähle {attribute} …"
+    VARIATION_NOT_AVAILABLE: "Diese Variante ist leider nicht verfügbar."
+    PRODUCT_NOT_AVAILABLE: "Das Produkt ist mit den ausgewählten Optionen nicht verfügbar."
+  PriceTag:
+    # Save as in savings (you saved this much from the original price)
+    SAVE: "Gespart"

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -21,6 +21,7 @@ en:
     PLURALNAME: "Account Pages"
     SINGULARNAME: "Account Page"
     Title: "Past Orders"
+    NO_PAGE: "No AccountPage was found. Please create one in the CMS!"
   AccountPage.ss:
     COMPLETED: "Completed Orders"
     HISTORY: "Your Order History"
@@ -60,7 +61,7 @@ en:
     CITYHINT: "or suburb, county, district"
     COUNTRY: Country
     PHONE: "Phone Number"
-    PLURALNAME: Addresss
+    PLURALNAME: Addresses
     POSTALCODE: "Postal Code"
     SINGULARNAME: Address
     STATE: State
@@ -83,6 +84,9 @@ en:
     has_one_Member: Member
   AddressBookCheckoutComponent:
     CREATENEWADDRESS: "Create new address"
+    EXISTING_BILLING_ADDRESS: "Existing Billing Address"
+    EXISTING_SHIPPING_ADDRESS: "Existing Shipping Address"
+    EXISTING_ADDRESS: "Existing Address"
   Cart.ss:
     ADDONE: "Add one more of \"%s\" to your cart"
     CheckoutClick: "Click here to go to the checkout"
@@ -131,6 +135,7 @@ en:
     PASSWORD: Password
     SURNAME: Surname
     TERMSANDCONDITIONS: "I agree to the terms and conditions stated on the <a href=\"%s\" target=\"new\" class=\"read_terms\" title=\"Read the shop terms and conditions for this site\">terms and conditions</a> page"
+    PAYMENT_TYPE: "Payment Type"
   CheckoutFields:
     PAYMENTTYPE: "Payment Type"
   CheckoutForm:
@@ -143,6 +148,8 @@ en:
     SINGULARNAME: "Checkout Page"
     TITLE: Checkout
     db_PurchaseComplete: "Purchase Complete"
+    PURCHASE_COMPLETE_DESCRIPTION: "This message is included in reciept email, after the customer submits the checkout"
+    SUBMIT_PAYMENT: "Submit Payment"
   CheckoutPage.ss:
     CARTEMPTY: "Your cart is empty."
     CHECKOUT: Checkout
@@ -197,6 +204,8 @@ en:
     PRINT: Print
     SINGULARNAME: Order
     SUCCESSFULL: "Order Successful"
+    DATE_FROM: "Date from"
+    DATE_TO: "Date to"
     db_AnalyticsSubmitted: "Analytics Submitted"
     db_Dispatched: Dispatched
     db_Email: Email
@@ -230,6 +239,7 @@ en:
     OUTSTANDING: "Outstanding: %s"
     PAYMENTMETHOD: "Payment Method"
     PAYORDER: "Pay outstanding balance"
+    MANUAL_NOT_ALLOWED: "Manual payment not allowed"
   OrderAdmin_Addresses.ss:
     ADDRESS: Address
     BILLTO: "Bill To"
@@ -435,6 +445,7 @@ en:
     PAYMENTSTATUS: "Payment Status"
     TABLESUMMARY: "The contents of your cart are displayed in this form and summary of all fees associated with an order and a rundown of payments options."
   PaymentProcessor:
+    INVALID_GATEWAY: "`{gateway}` isn't a valid payment gateway."
     CANTPAY: "Order can't be paid for."
   PaystationHostedPayment:
     PLURALNAME: "Paystation Hosted Payments"
@@ -451,6 +462,7 @@ en:
     CATEGORY: Category
     CATEGORYDESCRIPTION: "This is the parent page or default category."
     CODE: "Product Code/SKU"
+    CODE_SHORT: "SKU"
     COSTPRICE: "Cost Price"
     COSTPRICEDESC: "Wholesale price before markup."
     DEPTH: "Depth (%s)"
@@ -466,6 +478,7 @@ en:
     SINGULARNAME: Product
     WEIGHT: "Weight (%s)"
     WIDTH: "Width (%s)"
+    NO_IMAGE: "no image"
     db_AllowPurchase: "Allow Purchase"
     db_BasePrice: "Base Price"
     db_CostPrice: "Cost Price"
@@ -502,6 +515,7 @@ en:
   ProductAttributeType:
     PLURALNAME: Attributes
     SINGULARNAME: Attribute
+    SAVE_FIRST_MESSAGE: "Save first, then you can add values."
     belongs_many_many_Product: Product
     db_Label: Label
     db_Name: Name
@@ -542,6 +556,9 @@ en:
     NEXT: next
     PAGE: page
     PREVIOUS: previous
+    VIEW_PREVIOUS: "View the previous page"
+    VIEW_NEXT: "View the next page"
+    VIEW_PAGE: "View page number {pageNum}"
   ProductGroupItem.ss:
     ADD: "Add \"%s\" to your cart"
     ADDLINK: "Add to Cart"
@@ -560,6 +577,13 @@ en:
     has_one_Image: Image
     has_one_Product: Product
     many_many_AttributeValues: "Attribute Values"
+    NO_ATTRIBUTE_VALUES_MESSAGE: "{attribute} has no values to choose from. You can create them in the \"Products\" &#62; \"Product Attribute Type\" section of the CMS."
+    SAVE_FIRST_MESSAGE: "You can choose variation attributes after saving for the first time, if they exist."
+  ProductVariationsExtension:
+    ATTRIBUTES: "Attributes"
+    ATTRIBUTES_DESCRIPTION: "These are fields to indicate the way(s) each variation varies. Once selected, they can be edited on each variation."
+    VARIATIONS: "Variations"
+    VARIATIONS_INSTRUCTIONS: "Price - Because you have one or more variations, the price can be set in the \"Variations\" tab."
   ProductVariation_OrderItem:
     PLURALNAME: Items
     SINGULARNAME: Item
@@ -589,6 +613,8 @@ en:
     CUSTOMERGROUP: "Group to add new customers to"
     DEFAULTIMAGE: "Default Product Image"
     TERMSPAGE: "Terms and Conditions Page"
+    ALLOWED_COUNTRIES: "Allowed Ordering and Shipping Countries"
+    ALLOWED_COUNTRIES_TAB_TITLE: "Allowed Countries"
   ShopCurrency:
     FREE: "<span class=\"free\">FREE</span>"
   ShopDashboard:
@@ -598,6 +624,13 @@ en:
     RecentAccountsDescription: "Shows recent account signups"
     RecentOrdersChart: "Order History Chart"
     RecentOrdersChartDescription: "Shows recent orders on a graph"
+    NUMBER_OF_ACCOUNTS: "Number of accounts to show"
+    NUMBER_OF_DAYS: "Number of days to show"
+    NUMBER_OF_ORDERS: "Number of orders to show"
+    # These should probably be moved into a more generic category, since they can be used in a lot of places
+    EDIT: "Edit"
+    CUSTOMER: "Customer"
+    DATE: "Date"
   ShopDatabaseAdmin.ss:
     BUILDTASKS: "Build Tasks"
     CARTCLEANUP: "Cleanup old carts"
@@ -647,6 +680,11 @@ en:
     NOORDER: "No current order."
     PRODUCTNOTFOUND: "Product not found."
     QUANTITYSET: "Quantity has been set."
+    # Pretty generic translation, could be moved to a more generic category
+    CHANGE: "Change"
+    ITEMS_IN_CART_PLURAL: "There are <a href=\"{link}\">{quantity} items</a> in your cart."
+    ITEMS_IN_CART_SINGULAR: "There is <a href=\"{link}\">1 item</a> in your cart."
+    CHECKOUT: "Checkout"
   SideCart.ss:
     HEADLINE: "My Cart"
     NOITEMS: "There are no items in your cart"
@@ -693,3 +731,40 @@ en:
   shop:
     Checkout: "Payment Type"
     STATUS: Status
+  CartEditField:
+    REMOVE: "Remove"
+    VARIATION: "Variation"
+  CartForm:
+    UPDATE_CART: "Update Cart"
+    REMOVED_ITEMS: "Removed {count} items."
+    UPDATED_ITEMS: "Updated {count} items."
+  OnsitePaymentCheckoutComponent:
+    CREDIT_CARD_INVALID: "Credit card is invalid"
+  PaymentCheckoutComponent:
+    NO_PAYMENT_METHOD: "Payment method not provided"
+    UNSUPPORTED_GATEWAY: "Gateway not supported"
+  CheckoutStep:
+    # These should probably go somewhere else, as they are pretty generic.
+    CONTINUE: "Continue"
+    SHIPPING: "Shipping"
+    SUMMARY: "Summary"
+    GRAND_TOTAL: "Grand Total"
+  CheckoutStep_Address:
+    SUPPLY_CONTACT_INFO: "Supply your contact information"
+    SEPARATE_BILLING: "Bill to a different address from this"
+    ENTER_SHIPPING_ADDRESS: "Please enter your shipping address details."
+    BILL_TO: "Bill To:"
+    SHIP_TO: "Ship To:"
+  CheckoutStep_Membership:
+    CONTINUE_AS_GUEST: "Continue as Guest"
+    # This is an option presented to the user
+    CREATE_ACCOUNT: "Create an Account"
+    # This is an action (Button label)
+    CREATE_NEW_ACCOUNT: 'Create new Account'
+  VariationForm:
+    CHOOSE_ATTRIBUTE: "Choose {attribute} …"
+    VARIATION_NOT_AVAILABLE: "That variation is not available, sorry."
+    PRODUCT_NOT_AVAILABLE: "This product is not available with the selected options."
+  PriceTag:
+    # Save as in savings (you saved this much from the original price)
+    SAVE: "Save"

--- a/templates/Includes/Cart.ss
+++ b/templates/Includes/Cart.ss
@@ -15,7 +15,7 @@
 				<th scope="col"><% _t("QUANTITY", "Quantity") %></th>
 				<th scope="col"><% _t("TOTALPRICE","Total Price") %> ($Currency)</th>
 				<% if $Editable %>
-					<th scope="col"><% _t("REMOVE","Remove") %></th>
+					<th scope="col"><%t CartEditField.REMOVE "Remove" %></th>
 				<% end_if %>
 			</tr>
 		</thead>
@@ -41,7 +41,7 @@
 						</h3>
 						<% if $SubTitle %><p class="subtitle">$SubTitle</p><% end_if %>
 						<% if $Product.Variations && $Editable %>
-							Change: $VariationField
+							<%t ShoppingCart.CHANGE "Change" %>: $VariationField
 						<% end_if %>
 					</td>
 					<td>$UnitPrice.Nice</td>

--- a/templates/Includes/PriceTag.ss
+++ b/templates/Includes/PriceTag.ss
@@ -6,7 +6,7 @@
 			<small class="fractional">$Price.Fractional</small>
 			<span class="code">$Price.CurrencyCode</span>
 		</span>
-		<span class="discounted">$DiscountedPrice.Nice</span> Save: <span class="savings">$DiscountedPrice.Savings</span>
+		<span class="discounted">$DiscountedPrice.Nice</span> <%t PriceTag.SAVE "Save" %>: <span class="savings">$DiscountedPrice.Savings</span>
 	<% else %>
 		<span class="original"><strong class="price">$Price.Nice</strong></span>
 	<% end_if %>

--- a/templates/Includes/ProductGroupPagination.ss
+++ b/templates/Includes/ProductGroupPagination.ss
@@ -2,7 +2,7 @@
 <div id="PageNumbers">
 	<p><% _t('ProductGroup.PAGE','page') %>:
 		<% if $Products.NotFirstPage %>
-			<a class="prev" href="$Products.PrevLink" title="View the previous page"><% _t('ProductGroup.PREVIOUS','previous') %></a>
+			<a class="prev" href="$Products.PrevLink" title="<%t ProductGroup.VIEW_PREVIOUS "View the previous page" %>"><% _t('ProductGroup.PREVIOUS','previous') %></a>
 		<% end_if %>
 
 		<span>
@@ -11,7 +11,7 @@
 					$PageNum
 				<% else %>
 					<% if $Link %>
-						<a href="$Link" title="View page number $PageNum">$PageNum</a>
+						<a href="$Link" title="<%t ProductGroup.VIEW_PAGE "View page number {pageNum}" pageNum=$PageNum %>">$PageNum</a>
 					<% else %>
 						&hellip;
 					<% end_if %>
@@ -20,7 +20,7 @@
 		</span>
 
 		<% if $Products.NotLastPage %>
-			<a class="next" href="$Products.NextLink" title="View the next page"><% _t('ProductGroup.NEXT','next') %></a>
+			<a class="next" href="$Products.NextLink" title="<%t ProductGroup.VIEW_NEXT "View the next page" %>"><% _t('ProductGroup.NEXT','next') %></a>
 		<% end_if %>
 	</p>
 </div>

--- a/templates/Includes/SideCart.ss
+++ b/templates/Includes/SideCart.ss
@@ -3,9 +3,15 @@
 	<h3><% _t("HEADLINE","My Cart") %></h3>
 	<% if $Cart %>
 		<% with $Cart %>
-			<p class="itemcount">There <% if $Items.Plural %>are<% else %>is<% end_if %> <a href="$Top.CartLink">$Items.Quantity item<% if $Items.Plural %>s<% end_if %></a> in your cart.</p>
+			<p class="itemcount">
+				<% if $Items.Plural %>
+					<%t ShoppingCart.ITEMS_IN_CART_PLURAL 'There are <a href="{link}">{quantity} items</a> in your cart.' link=$Top.CartLink quantity=$Items.Quantity %>
+				<% else %>
+					<%t ShoppingCart.ITEMS_IN_CART_SINGULAR 'There is <a href="{link}">1 item</a> in your cart.' link=$Top.CartLink %>
+				<% end_if %>
+			</p>
 			<div class="checkout">
-				<a href="$Top.CheckoutLink">Checkout</a>
+				<a href="$Top.CheckoutLink"><%t ShoppingCart.CHECKOUT "Checkout" %></a>
 			</div>
 			<% loop $Items %>
 				<div class="item $EvenOdd $FirstLast">

--- a/templates/Includes/VariationsTable.ss
+++ b/templates/Includes/VariationsTable.ss
@@ -1,6 +1,10 @@
 <table class="variationstable">
 	<tr>
-		<th>Variation</th><th>Price</th><% if $canPurchase %><th><% _t("QUANTITYCART","Quantity in cart") %></th><% end_if %>
+		<th><%t ProductVariation.SINGULARNAME "Variation" %></th>
+		<th><%t Product.PRICE "Price" %></th>
+		<% if $canPurchase %>
+			<th><% _t("QUANTITYCART","Quantity in cart") %></th>
+		<% end_if %>
 	</tr>
 	<% loop $Variations %>
 			<tr>

--- a/templates/Layout/Product.ss
+++ b/templates/Layout/Product.ss
@@ -14,7 +14,7 @@
 		<% if $Image.ContentImage %>
 			<img class="productImage" src="$Image.ContentImage.URL" alt="<% sprintf(_t("IMAGE","%s image"),$Title) %>" />
 		<% else %>
-			<div class="noimage">no image</div>
+			<div class="noimage"><%t Product.NO_IMAGE "no image" %></div>
 		<% end_if %>
 		<% if $InternalItemID %><p><% _t("CODE","Product Code") %>: {$InternalItemID}</p><% end_if %>
 		<% if $Model %><p><% _t("MODEL","Model") %>: $Model.XML</p><% end_if %>

--- a/templates/Layout/SteppedCheckoutPage.ss
+++ b/templates/Layout/SteppedCheckoutPage.ss
@@ -43,7 +43,7 @@
 						<div class="accordion-body">
 							<div class="accordion-inner">
 								<% if $IsCurrentStep('contactdetails') %>
-									<p>Supply your contact information</p>
+									<p><%t CheckoutStep_Address.SUPPLY_CONTACT_INFO "Supply your contact information" %></p>
 									$OrderForm
 								<% end_if %>
 								<% if $IsPastStep('contactdetails') %>
@@ -59,9 +59,11 @@
 				<div class="accordion-group">
 					<div class="accordion-heading">
 						<% if $IsPastStep('shippingaddress') %>
-							<h3><a class="accordion-toggle" title="edit address(es)" href="$Link('shippingaddress')">Address</a></h3>
+							<h3><a class="accordion-toggle" title="edit address(es)" href="$Link('shippingaddress')">
+								<%t Address.SINGULARNAME "Address" %>
+							</a></h3>
 						<% else %>
-							<h3 class="accordion-toggle">Address</h3>
+							<h3 class="accordion-toggle"><%t Address.SINGULARNAME "Address" %></h3>
 						<% end_if %>
 					</div>
 					<% if $IsFutureStep('shippingaddress') %>
@@ -70,19 +72,19 @@
 						<div class="accordion-body">
 							<div class="accordion-inner">
 								<% if $IsCurrentStep('shippingaddress') %>
-									<p>Please enter your shipping address details.</p>
+									<p><%t CheckoutStep_Address.ENTER_SHIPPING_ADDRESS "Please enter your shipping address details." %></p>
 									$OrderForm
 								<% end_if %>
 								<% if $IsPastStep('shippingaddress') %>
 									<div class="row">
 										<div class="span4">
 											<% with $Cart %>
-												<h4>Ship To:</h4>
+												<h4><%t CheckoutStep_Address.SHIP_TO "Ship To:" %></h4>
 												$ShippingAddress
 											<% end_with %>
 										</div>
 										<div class="span4">
-										<h4>Bill To:</h4>
+										<h4><%t CheckoutStep_Address.BILL_TO "Bill To:" %></h4>
 											<% if $IsCurrentStep('billingaddress') %>
 												$OrderForm
 											<% else %>
@@ -101,9 +103,11 @@
 				<div class="accordion-group">
 					<div class="accordion-heading">
 						<% if $IsPastStep('shippingmethod') %>
-							<h3><a class="accordion-toggle" title="choose shipping method" href="$Link('shippingmethod')">Shipping</a></h3>
+							<h3><a class="accordion-toggle" title="choose shipping method" href="$Link('shippingmethod')">
+								<%t CheckoutStep.SHIPPING "Shipping" %>
+							</a></h3>
 						<% else %>
-							<h3 class="accordion-toggle">Shipping</h3>
+							<h3 class="accordion-toggle"><%t CheckoutStep.SHIPPING "Shipping" %></h3>
 						<% end_if %>
 					</div>
 					<% if $IsFutureStep('shippingmethod') %>
@@ -127,9 +131,11 @@
 				<div class="accordion-group">
 					<div class="accordion-heading">
 						<% if $IsPastStep('paymentmethod') %>
-							<h3><a class="accordion-toggle" title="choose payment method" href="$Link('paymentmethod')">Payment Method</a></h3>
+							<h3><a class="accordion-toggle" title="choose payment method" href="$Link('paymentmethod')">
+								<%t OrderActionsForm.PAYMENTMETHOD "Payment Method" %>
+							</a></h3>
 						<% else %>
-							<h3 class="accordion-toggle">Payment Method</h3>
+							<h3 class="accordion-toggle"><%t OrderActionsForm.PAYMENTMETHOD "Payment Method" %></h3>
 						<% end_if %>
 					</div>
 					<% if $IsFutureStep('paymentmethod') %>
@@ -150,7 +156,7 @@
 
 				<div class="accordion-group">
 					<div class="accordion-heading">
-						<h3 class="accordion-toggle">Summary</h3>
+						<h3 class="accordion-toggle"><%t CheckoutStep.SUMMARY "Summary" %></h3>
 					</div>
 					<% if $IsFutureStep('summary') %>
 
@@ -170,7 +176,7 @@
 													<% end_if %>
 												<% end_loop %>
 												<tr>
-													<th colspan="3">Grand Total</th>
+													<th colspan="3"><%t CheckoutStep.GRAND_TOTAL "Grand Total" %></th>
 													<td>$Total.Nice $Currency</td>
 												</tr>
 											</tfoot>
@@ -191,7 +197,8 @@
 <% else %>
 
 	<div class="message warning alert alert-block alert-info">
-		<h4 class="alert-heading">Your cart is empty</h4>
+		<h4 class="alert-heading">
+			<% _t('CartPage.ss.CARTEMPTY','Your cart is empty') %></h4>
 		<i class="icon icon-info-sign"></i> <% _t("NOITEMS","There are no items in your cart.") %>
 	</div>
 

--- a/templates/admin/OrderAdmin_Content_ItemLine.ss
+++ b/templates/admin/OrderAdmin_Content_ItemLine.ss
@@ -17,7 +17,7 @@
 		<% end_if %>
 		</strong>
 		<% if $SubTitle %><div class="subtitle">$SubTitle</div><% end_if %>
-		<% if $Buyable.InternalItemID %><div class="sku">SKU: $Buyable.InternalItemID</div><% end_if %>
+		<% if $Buyable.InternalItemID %><div class="sku"><%t Product.CODE_SHORT "SKU" %>: $Buyable.InternalItemID</div><% end_if %>
 	</td>
 	<td class="unitprice">$UnitPrice.Nice</td>
 	<td class="quantity count-$Quantity">$Quantity</td>

--- a/templates/admin/OrderAdmin_Customer.ss
+++ b/templates/admin/OrderAdmin_Customer.ss
@@ -6,8 +6,8 @@
 			</th>
 		</tr>
 		<tr class="header">
-			<th class="main">Name</th>
-			<th class="main">Email</th>
+			<th class="main"><%t AccountNavigation.MemberName "Name" %></th>
+			<th class="main"><%t AccountNavigation.MemberEmail "Email" %></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/dashboard/DashboardRecentMembersPanel.ss
+++ b/templates/dashboard/DashboardRecentMembersPanel.ss
@@ -2,9 +2,9 @@
 	<table class="table table-bordered">
 		<thead>
 			<tr>
-				<td>Date</td>
-				<th>Email</th>
-				<th>Name</th>
+				<td><%t AccountNavigation.MemberSince "Member Since" %></td>
+				<th><%t AccountNavigation.MemberEmail "Email" %></th>
+				<th><%t AccountNavigation.MemberName "Name" %></th>
 				<th></th>
 			</tr>
 		</thead>
@@ -15,7 +15,9 @@
 					<td>$Email</td>
 					<td>$Surname, $FirstName</td>
 					<td>
-						<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/security/EditForm/field/Members/item/$ID/edit">Edit</a>
+						<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/security/EditForm/field/Members/item/$ID/edit">
+							<%t ShopDashboard.EDIT "Edit" %>
+						</a>
 					</td>
 				</tr>
 			<% end_loop %>

--- a/templates/dashboard/DashboardRecentOrdersPanel.ss
+++ b/templates/dashboard/DashboardRecentOrdersPanel.ss
@@ -3,13 +3,13 @@
 		<table class="table table-bordered orderhistory">
 			<thead>
 				<tr>
-					<th>Reference</th>
-					<th>Date</th>
-					<th>Customer</th>
-					<th>Email</th>
-					<th>Items</th>
-					<th>Total</th>
-					<th>Status</th>
+					<th><%t Order.db_Reference "Reference" %></th>
+					<th><%t ShopDashboard.DATE "Date" %></th>
+					<th><%t ShopDashboard.CUSTOMER "Customer" %></th>
+					<th><%t AccountNavigation.EMAIL "Email" %></th>
+					<th><%t Order.has_many_Items "Items" %></th>
+					<th><%t Order.db_Total "Total" %></th>
+					<th><%t Order.db_Status "Status" %></th>
 					<th></th>
 				</tr>
 			</thead>
@@ -24,7 +24,9 @@
 						<td>$Total.Nice</td>
 						<td>$Status</td>
 						<td>
-							<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/orders/Order/EditForm/field/Order/item/$ID/edit">Edit</a>
+							<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/orders/Order/EditForm/field/Order/item/$ID/edit">
+								<%t ShopDashboard.EDIT "Edit" %>
+							</a>
 						</td>
 					</tr>
 				<% end_loop %>
@@ -36,9 +38,9 @@
 		<table class="table table-bordered orderhistory">
 			<thead>
 				<tr>
-					<th>Reference</th>
-					<th>Customer</th>
-					<th>Total</th>
+          <th><%t Order.db_Reference "Reference" %></th>
+          <th><%t ShopDashboard.CUSTOMER "Customer" %></th>
+          <th><%t Order.db_Total "Total" %></th>
 					<th></th>
 				</tr>
 			</thead>
@@ -49,7 +51,9 @@
 						<td>$Surname, $FirstName</td>
 						<td>$Total.Nice</td>
 						<td>
-							<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/orders/Order/EditForm/field/Order/item/$ID/edit">Edit</a>
+							<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/orders/Order/EditForm/field/Order/item/$ID/edit">
+								<%t ShopDashboard.EDIT "Edit" %>
+							</a>
 						</td>
 					</tr>
 				<% end_loop %>


### PR DESCRIPTION
Here's what I did:
 - Went through all template files and wrapped strings that should be translated with appropriate calls.
 - Looked through all PHP files and wrapped all strings that should be translated in `_t` calls.
 - Added missing keys/values to `en.yml`.
 - Added new translations to `de.yml`.
 - Fixing typo in code along the way (CartEditField.php) `Closure`.

This PR aims to make the Shop-Module fully translatable, while not breaking backward-compatibility (eg. for the 1.x branch).
No existing keys/values have been removed or altered (except for typos).
Some new values had to be added.
