### PR TITLE
Use localized field-names in error- and validation-messages.

### DIFF
--- a/code/account/ShopAccountForm.php
+++ b/code/account/ShopAccountForm.php
@@ -84,12 +84,17 @@ class ShopAccountFormValidator extends RequiredFields{
 			$currentmember = Member::currentUser();
 			//can't be taken
 			if(DataObject::get_one('Member', "$field = '$uid' AND ID != ".$currentmember->ID)){
+				// get localized field labels
+				$fieldLabels = $currentmember->fieldLabels(false);
+				// if a localized value exists, use this for our error-message
+				$fieldLabel = isset($fieldLabels[$field]) ? $fieldLabels[$field] : $field;
+
 				$this->validationError(
 					$field,
 					// re-use the message from checkout
 					sprintf(
 						_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
-						$field, $uid
+						$fieldLabel, $uid
 					),
 					"required"
 				);

--- a/code/account/ShopMemberFactory.php
+++ b/code/account/ShopMemberFactory.php
@@ -30,11 +30,15 @@ class ShopMemberFactory{
 			throw new ValidationException($result);
 		}
 		$idval = $data[$idfield];
-		if(ShopMember::get_by_identifier($idval)){
+		if($member = ShopMember::get_by_identifier($idval)){
+			// get localized field labels
+			$fieldLabels = $member->fieldLabels(false);
+			// if a localized value exists, use this for our error-message
+			$fieldLabel = isset($fieldLabels[$idfield]) ? $fieldLabels[$idfield] : $idfield;
+
 			$result->error(sprintf(
 				_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
-				_t("Member.".$idfield, $idfield),
-				$idval
+				$fieldLabel, $idval
 			));
 			throw new ValidationException($result);
 		}

--- a/code/checkout/components/AddressBookCheckoutComponent.php
+++ b/code/checkout/components/AddressBookCheckoutComponent.php
@@ -97,12 +97,16 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 		} else {
 			// Otherwise, require the normal address fields
 			$required = parent::getRequiredFields($order);
+			$addressLabels = singleton('Address')->fieldLabels(false);
+
 			foreach ($required as $fieldName) {
 				if (empty($data[$fieldName])) {
+					// attempt to get the translated field name
+					$fieldLabel = isset($addressLabels[$fieldName]) ? $addressLabels[$fieldName] : $fieldName;
 					$errorMessage = _t(
 						'Form.FIELDISREQUIRED',
 						'{name} is required',
-						array('name' => $fieldName)
+						array('name' => $fieldLabel)
 					);
 
 					$result->error($errorMessage, $fieldName);

--- a/code/checkout/components/MembershipCheckoutComponent.php
+++ b/code/checkout/components/MembershipCheckoutComponent.php
@@ -5,7 +5,7 @@
  * 	- member identifier, and password fields.
  * 	- required membership fields
  * 	- validating data
- * 
+ *
  */
 class MembershipCheckoutComponent extends CheckoutComponent{
 
@@ -72,10 +72,14 @@ class MembershipCheckoutComponent extends CheckoutComponent{
 			$idfield = Member::config()->unique_identifier_field;
 			$idval = $data[$idfield];
 			if(ShopMember::get_by_identifier($idval)){
+				// get localized field labels
+				$fieldLabels = $member->fieldLabels(false);
+				// if a localized value exists, use this for our error-message
+				$fieldLabel = isset($fieldLabels[$idfield]) ? $fieldLabels[$idfield] : $idfield;
 				$result->error(
 					sprintf(
 						_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
-						$idfield, $idval
+						$fieldLabel, $idval
 					), $idval
 				);
 			}


### PR DESCRIPTION
If field-labels are translated, use them in error-messages. If there's no translation, keep the field-name.