### PR TITLE
Allow hooking into `getCountryField`

### DIFF
--- a/code/model/Address.php
+++ b/code/model/Address.php
@@ -98,10 +98,14 @@ class Address extends DataObject{
 				array_pop($countries)
 			);
 		}
-		return DropdownField::create("Country",
+		$field = DropdownField::create("Country",
 			_t('Address.COUNTRY', 'Country'),
-				$countries
+			$countries
 		)->setHasEmptyDefault(true);
+
+		$this->extend('updateCountryField', $field);
+
+		return $field;
 	}
 
 	/**


### PR DESCRIPTION
I'm using this for setting Germany as the default country like this:

	public function updateCountryField($field) {
		$field->setHasEmptyDefault(false);
		$field->setValue('DE');
	}