### PR TITLE
Fix for #405

### DIFF
--- a/tests/ShopTest.php
+++ b/tests/ShopTest.php
@@ -8,8 +8,6 @@
 class ShopTest{
 
 	public static function setConfiguration() {
-		$ds = DIRECTORY_SEPARATOR;
-		include BASE_PATH.$ds.SHOP_DIR.$ds.'tests'.$ds.'test_config.php';
+        include __DIR__ . DIRECTORY_SEPARATOR . 'test_config.php';
 	}
-
 }

--- a/tests/cms/ProductBulkLoaderTest.php
+++ b/tests/cms/ProductBulkLoaderTest.php
@@ -9,7 +9,8 @@ class ProductBulkLoaderTest extends FunctionalTest {
 	public function testLoad() {
 		$loader = new ProductBulkLoader('Product');
 
-		$filepath = Director::baseFolder() . '/'.SHOP_DIR.'/tests/test_products.csv';
+		$ds = DIRECTORY_SEPARATOR;
+        $filepath = realpath(__DIR__ . $ds . '..' . $ds . 'test_products.csv');
 		$file = fopen($filepath, 'r');
 
 		fgetcsv($file); // pop header row


### PR DESCRIPTION
Don't rely on silverstripe path, but rather use paths that are calculated relative to the file. Allows execution of tests when folders are symlinked.