### PR TITLE
Updated OrderStatusLog.php

### DIFF
--- a/code/model/OrderStatusLog.php
+++ b/code/model/OrderStatusLog.php
@@ -82,7 +82,7 @@ class OrderStatusLog extends DataObject {
 
 	public function onAfterWrite() {
 		if($this->SentToCustomer) {
-			$this->order()->sendStatusChange($this->Title, $this->Note);
+			$this->order()->notifier->sendStatusChange($this->Title, $this->Note);
 		}
 	}
 


### PR DESCRIPTION
The OrderProcessor class has a depreciation notice on it's sendStatusChange function.  Send a status change via the notifier property on the Order class instead.  Thanks.