### PR TITLE
Cleaning up translations in all PHP and template files.

### DIFF
--- a/code/account/AccountPage.php
+++ b/code/account/AccountPage.php
@@ -37,7 +37,7 @@ class AccountPage extends Page {
 		if($page = DataObject::get_one('AccountPage')) {
 			return $page;
 		}
-		user_error(_t('AccountPage.NO_PAGE', 'No AccountPage was found. Please create one in the CMS!'), E_USER_ERROR);
+		user_error(_t('AccountPage.NoPage', 'No AccountPage was found. Please create one in the CMS!'), E_USER_ERROR);
 	}
 
 	/**
@@ -80,12 +80,12 @@ class AccountPage_Controller extends Page_Controller {
 		if(!Member::currentUserID()) {
 			$messages = array(
 				'default' => _t(
-					'AccountPage.LOGIN',
+					'AccountPage.Login',
 					'You\'ll need to login before you can access the account page.
 					If you are not registered, you won\'t be able to access it until
 					you make your first order, otherwise please enter your details below.'),
 				'logInAgain' => _t(
-					'AccountPage.LOGINAGAIN',
+					'AccountPage.LoginAgain',
 					'You have been logged out. If you would like to log in again,
 					please do so below.')
 			);
@@ -99,7 +99,7 @@ class AccountPage_Controller extends Page_Controller {
 		if($this->dataRecord && $title = $this->dataRecord->Title){
 			return $title;
 		}
-		return _t('AccountPage.Title', "Account");
+		return _t('AccountPage.DefaultTitle', "Account");
 	}
 
 	public function getMember() {
@@ -179,7 +179,7 @@ class AccountPage_Controller extends Page_Controller {
 			$member->DefaultBillingAddressID = $address->ID;
 			$member->write();
 		}
-		$form->sessionMessage(_t("CreateAddressForm.SAVED", "Your address has been saved"), "good");
+		$form->sessionMessage(_t("CreateAddressForm.AddressSaved", "Your address has been saved"), "good");
 		$this->redirect($this->Link('addressbook'));
 	}
 

--- a/code/account/OrderActionsForm.php
+++ b/code/account/OrderActionsForm.php
@@ -37,24 +37,26 @@ class OrderActionsForm extends Form{
 			}
 			if(!empty($gateways)){
 				$fields->push(HeaderField::create("MakePaymentHeader",
-					_t("OrderActionsForm.MAKEPAYMENT", "Make Payment"))
+					_t("OrderActionsForm.MakePayment", "Make Payment"))
 				);
 				$outstandingfield = Currency::create();
 				$outstandingfield->setValue($order->TotalOutstanding());
 				$fields->push(LiteralField::create("Outstanding",
-					sprintf(
-						_t("OrderActionsForm.OUTSTANDING", "Outstanding: %s"),
-						$outstandingfield->Nice()
-					)
+                    _t(
+                        'Order.OutstandingWithAmount',
+                        'Outstanding: {Amount}',
+                        '',
+                        array('Amount' => $outstandingfield->Nice())
+                    )
 				));
 				$fields->push(OptionsetField::create('PaymentMethod',
-					_t("OrderActionsForm.PAYMENTMETHOD", "Payment Method"),
+					_t("OrderActionsForm.PaymentMethod", "Payment Method"),
 					$gateways,
 					key($gateways)
 				));
 
 				$actions->push(FormAction::create('dopayment',
-					_t('OrderActionsForm.PAYORDER', 'Pay outstanding balance')
+					_t('OrderActionsForm.PayOrder', 'Pay outstanding balance')
 				));
 			}
 
@@ -63,7 +65,7 @@ class OrderActionsForm extends Form{
 		if(self::config()->allow_cancelling && $order->canCancel()){
 			$actions->push(
 				FormAction::create('docancel',
-					_t('OrderActionsForm.CANCELORDER', 'Cancel this order')
+					_t('OrderActionsForm.CancelOrder', 'Cancel this order')
 				)
 			);
 		}
@@ -100,13 +102,13 @@ class OrderActionsForm extends Form{
 					$form->sessionMessage($processor->getError(), 'bad');
 				}
 			}else{
-				$form->sessionMessage(_t('OrderActionsForm.MANUAL_NOT_ALLOWED', "Manual payment not allowed"), 'bad');
+				$form->sessionMessage(_t('OrderActionsForm.ManualNotAllowed', "Manual payment not allowed"), 'bad');
 			}
 
 			return $this->controller->redirectBack();
 		}
 		$form->sessionMessage(
-			_t('OrderForm.COULDNOTPROCESSPAYMENT', 'Payment could not be processed.'),
+			_t('OrderForm.CouldNotProcessPayment', 'Payment could not be processed.'),
 			'bad'
 		);
 		$this->controller->redirectBack();
@@ -130,16 +132,18 @@ class OrderActionsForm extends Form{
 			if(self::config()->email_notification){
 				$email = new Email(
 					Email::config()->admin_email, Email::config()->admin_email,
-					sprintf(
-						_t('Order.CANCELSUBJECT', 'Order #%d cancelled by member'),
-						$this->order->ID
-					),
+                    _t(
+                        'ShopEmail.CancelSubject',
+                        'Order #{OrderNo} cancelled by member',
+                        '',
+                        array('OrderNo' => $this->order->Reference)
+                    ),
 					$this->order->renderWith('Order')
 				);
 				$email->send();
 			}
 			$this->controller->sessionMessage(
-				_t("OrderForm.ORDERCANCELLED", "Order sucessfully cancelled"),
+				_t("OrderForm.OrderCancelled", "Order sucessfully cancelled"),
 				'warning'
 			);
 			if(Member::currentUser() && $link = $this->order->Link()){

--- a/code/account/ShopAccountForm.php
+++ b/code/account/ShopAccountForm.php
@@ -19,12 +19,12 @@ class ShopAccountForm extends Form {
 			$fields = new FieldList();
 		}
 		if(get_class($controller) == 'AccountPage_Controller'){
-			$actions = new FieldList(new FormAction('submit', _t('MemberForm.SAVE', 'Save Changes')));
+			$actions = new FieldList(new FormAction('submit', _t('MemberForm.Save', 'Save Changes')));
 		}
 		else{
 			$actions = new FieldList(
-				new FormAction('submit', _t('MemberForm.SAVE', 'Save Changes')),
-				new FormAction('proceed', _t('MemberForm.SAVEANDPROCEED', 'Save and proceed to checkout'))
+				new FormAction('submit', _t('MemberForm.Save', 'Save Changes')),
+				new FormAction('proceed', _t('MemberForm.SaveAndProceed', 'Save and proceed to checkout'))
 			);
 		}
 		parent::__construct($controller, $name, $fields, $actions, $requiredFields);
@@ -46,7 +46,7 @@ class ShopAccountForm extends Form {
 
 		$form->saveInto($member);
 		$member->write();
-		$form->sessionMessage(_t("MemberForm.DETAILSSAVED", 'Your details have been saved'), 'good');
+		$form->sessionMessage(_t("MemberForm.DetailsSaved", 'Your details have been saved'), 'good');
 
 		Controller::curr()->redirectBack();
 		return true;
@@ -60,7 +60,7 @@ class ShopAccountForm extends Form {
 		if(!$member) return false;
 		$form->saveInto($member);
 		$member->write();
-		$form->sessionMessage(_t("MemberForm.DETAILSSAVED", 'Your details have been saved'), 'good');
+		$form->sessionMessage(_t("MemberForm.DetailsSaved", 'Your details have been saved'), 'good');
 		Controller::curr()->redirect(CheckoutPage::find_link());
 		return true;
 	}
@@ -92,10 +92,12 @@ class ShopAccountFormValidator extends RequiredFields{
 				$this->validationError(
 					$field,
 					// re-use the message from checkout
-					sprintf(
-						_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
-						$fieldLabel, $uid
-					),
+                    _t(
+                        'Checkout.MemberExists',
+                        'A member already exists with the {Field} {Identifier}',
+                        '',
+                        array('Field' => $fieldLabel, 'Identifier' => $uid)
+                    ),
 					"required"
 				);
 				$valid = false;

--- a/code/account/ShopMemberFactory.php
+++ b/code/account/ShopMemberFactory.php
@@ -14,19 +14,24 @@ class ShopMemberFactory{
 		$result = new ValidationResult();
 		if(!Checkout::member_creation_enabled()) {
 			$result->error(
-				_t("Checkout.MEMBERSHIPSNOTALLOWED", "Creating new memberships is not allowed")
+				_t("Checkout.MembershipIsNotAllowed", "Creating new memberships is not allowed")
 			);
 			throw new ValidationException($result);
 		}
 		$idfield = Config::inst()->get('Member', 'unique_identifier_field');
 		if(!isset($data[$idfield]) || empty( $data[$idfield])){
 			$result->error(
-				sprintf(_t("Checkout.IDFIELDNOTFOUND", "Required field not found: %s"), $idfield)
+                _t(
+                    'Checkout.IdFieldNotFound',
+                    'Required field not found: {IdentifierField}',
+                    'Identifier is the field that holds the unique user-identifier, commonly this is \'Email\'',
+                    array('IdentifierField' => $idfield)
+                )
 			);
 			throw new ValidationException($result);
 		}
 		if(!isset($data['Password']) || empty($data['Password'])){
-			$result->error(_t("Checkout.PASSWORDREQUIRED", "A password is required"));
+			$result->error(_t("Checkout.PasswordRequired", "A password is required"));
 			throw new ValidationException($result);
 		}
 		$idval = $data[$idfield];
@@ -36,10 +41,14 @@ class ShopMemberFactory{
 			// if a localized value exists, use this for our error-message
 			$fieldLabel = isset($fieldLabels[$idfield]) ? $fieldLabels[$idfield] : $idfield;
 
-			$result->error(sprintf(
-				_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
-				$fieldLabel, $idval
-			));
+			$result->error(
+                _t(
+                    'Checkout.MemberExists',
+                    'A member already exists with the {Field} {Identifier}',
+                    '',
+                    array('Field' => $fieldLabel, 'Identifier' => $idval)
+                )
+			);
 			throw new ValidationException($result);
 		}
 		$member = new Member(Convert::raw2sql($data));

--- a/code/address/SetLocationForm.php
+++ b/code/address/SetLocationForm.php
@@ -5,10 +5,10 @@ class SetLocationForm extends Form{
 	public function __construct($controller, $name = "SetLocationForm") {
 		$countries = SiteConfig::current_site_config()->getCountriesList();
 		$fields = new FieldList(
-			$countryfield = new DropdownField("Country", _t('SetLocationForm.COUNTRY', 'Country'), $countries)
+			$countryfield = new DropdownField("Country", _t('SetLocationForm.Country', 'Country'), $countries)
 		);
 		$countryfield->setHasEmptyDefault(true);
-		$countryfield->setEmptyString(_t('SetLocationForm.CHOOSECOUNTRY', 'Choose country...'));
+		$countryfield->setEmptyString(_t('SetLocationForm.ChooseCountry', 'Choose country...'));
 		$actions = new FieldList(
 			new FormAction("setLocation", "set")
 		);

--- a/code/cart/CartEditField.php
+++ b/code/cart/CartEditField.php
@@ -99,13 +99,13 @@ class CartEditField extends FormField{
 				if($variations->exists()){
 					$variationfield = DropdownField::create(
 						$name."[ProductVariationID]",
-						_t('CartEditField.VARIATION', "Variation"),
+						_t('Variation.SINGULARNAME', "Variation"),
 						$variations->map('ID', 'Title'),
 						$item->ProductVariationID
 					);
 				}
 			}
-			$remove = CheckboxField::create($name."[Remove]", _t('CartEditField.REMOVE', "Remove"));
+			$remove = CheckboxField::create($name."[Remove]", _t('Shop.Remove', "Remove"));
 			$editables->push($item->customise(array(
 				"QuantityField" => $quantity,
 				"VariationField" => $variationfield,

--- a/code/cart/CartForm.php
+++ b/code/cart/CartForm.php
@@ -15,7 +15,7 @@ class CartForm extends Form{
 				->setTemplate($template)
 		);
 		$actions = new FieldList(
-			FormAction::create("updatecart", _t('CartForm.UPDATE_CART', "Update Cart"))
+			FormAction::create("updatecart", _t('CartForm.UpdateCart', "Update Cart"))
 		);
 
 		parent::__construct($controller, $name, $fields, $actions);

--- a/code/cart/CartPage.php
+++ b/code/cart/CartPage.php
@@ -82,7 +82,7 @@ class CartPage_Controller extends Page_Controller{
 		if($this->Title){
 			return $this->Title;
 		}
-		return _t('CartPage.TITLE', "Shopping Cart");
+		return _t('CartPage.DefaultTitle', "Shopping Cart");
 	}
 
 	/**

--- a/code/cart/ShopQuantityField.php
+++ b/code/cart/ShopQuantityField.php
@@ -57,7 +57,7 @@ class ShopQuantityField extends ViewableData{
 		return NumericField::create(
 			$this->MainID() . '_Quantity',
 			// this title currently doesn't show up in the front end, better assign a translation anyway.
-			_t('AddProductForm.Quantity', "Quantity"),
+			_t('Order.Quantity', "Quantity"),
 			$this->item->Quantity
 		)->setAttribute('type','number');
 	}
@@ -114,7 +114,7 @@ class DropdownShopQuantityField extends ShopQuantityField{
 		return new DropdownField(
 			$this->MainID() . '_Quantity',
 			// this title currently doesn't show up in the front end, better assign a translation anyway.
-			_t('AddProductForm.Quantity', "Quantity"),
+			_t('Order.Quantity', "Quantity"),
 			$qtyArray, ($this->item->Quantity) ? $this->item->Quantity : "");
 	}
 

--- a/code/cart/ShoppingCart.php
+++ b/code/cart/ShoppingCart.php
@@ -123,11 +123,11 @@ class ShoppingCart {
 		$order->extend("beforeAdd", $buyable, $quantity, $filter);
 		if(!$buyable) {
 
-			return $this->error(_t("ShoppingCart.PRODUCTNOTFOUND", "Product not found."));
+			return $this->error(_t("ShoppingCart.ProductNotFound", "Product not found."));
 		}
 		$item = $this->findOrMakeItem($buyable, $filter);
 		if(!$item) {
-			
+
 			return false;
 		}
 		if(!$item->_brandnew) {
@@ -137,7 +137,7 @@ class ShoppingCart {
 		}
 		$item->write();
 		$order->extend("afterAdd", $item, $buyable, $quantity, $filter);
-		$this->message(_t("ShoppingCart.ITEMADD", "Item has been added successfully."));
+		$this->message(_t("ShoppingCart.ItemAdded", "Item has been added successfully."));
 
 		return $item;
 	}
@@ -154,13 +154,13 @@ class ShoppingCart {
 		$order = $this->current();
 
 		if(!$order) {
-			return $this->error(_t("ShoppingCart.NOORDER", "No current order."));
+			return $this->error(_t("ShoppingCart.NoOrder", "No current order."));
 		}
 
 		$order->extend("beforeRemove", $buyable, $quantity, $filter);
 
 		$item = $this->get($buyable, $filter);
-		
+
 		if(!$item) {
 			return false;
 		}
@@ -174,8 +174,8 @@ class ShoppingCart {
 			$item->write();
 		}
 		$order->extend("afterRemove", $item, $buyable, $quantity, $filter);
-		$this->message(_t("ShoppingCart.ITEMREMOVED", "Item has been successfully removed."));
-		
+		$this->message(_t("ShoppingCart.ItemRemoved", "Item has been successfully removed."));
+
 		return true;
 	}
 
@@ -202,8 +202,8 @@ class ShoppingCart {
 		$item->Quantity = $quantity;
 		$item->write();
 		$order->extend("afterSetQuantity", $item, $buyable, $quantity, $filter);
-		$this->message(_t("ShoppingCart.QUANTITYSET", "Quantity has been set."));
-		
+		$this->message(_t("ShoppingCart.QuantitySet", "Quantity has been set."));
+
 		return $item;
 	}
 
@@ -215,22 +215,24 @@ class ShoppingCart {
 	 */
 	private function findOrMakeItem(Buyable $buyable,$filter = array()) {
 		$order = $this->findOrMake();
-	
+
 		if(!$buyable || !$order){
 			return false;
 		}
-	
+
 		$item = $this->get($buyable, $filter);
-	
+
 		if(!$item) {
 			$member = Member::currentUser();
 
 			if(!$buyable->canPurchase($member)) {
 				return $this->error(
-					sprintf(_t("ShoppingCart.CANNOTPURCHASE",
-						"This %s cannot be purchased."),
-						strtolower($buyable->i18n_singular_name())
-					)
+                    _t(
+                        'ShoppingCart.CannotPurchase',
+                        'This {Title} cannot be purchased.',
+                        '',
+                        array('Title' => $buyable->i18n_singular_name())
+                    )
 				);
 				//TODO: produce a more specific message
 			}
@@ -271,7 +273,7 @@ class ShoppingCart {
 		$query = new MatchObjectFilter($itemclass, array_merge($customfilter, $filter), $required);
 		$item = $itemclass::get()->where($query->getFilter())->first();
 		if(!$item){
-			return $this->error(_t("ShoppingCart.ITEMNOTFOUND", "Item not found."));
+			return $this->error(_t("ShoppingCart.ItemNotFound", "Item not found."));
 		}
 
 		return $item;
@@ -299,10 +301,10 @@ class ShoppingCart {
 		$order = $this->current();
 		$this->order = null;
 		if(!$order){
-			return $this->error(_t("ShoppingCart.NOCARTFOUND", "No cart found."));
+			return $this->error(_t("ShoppingCart.NoCartFound", "No cart found."));
 		}
-		$order->write();	
-		$this->message(_t("ShoppingCart.CLEARED", "Cart was successfully cleared."));
+		$order->write();
+		$this->message(_t("ShoppingCart.Cleared", "Cart was successfully cleared."));
 
 		return true;
 	}
@@ -312,7 +314,7 @@ class ShoppingCart {
 	 */
 	protected function error($message) {
 		$this->message($message, "bad");
-		
+
 		return false;
 	}
 
@@ -337,7 +339,7 @@ class ShoppingCart {
 	public function clearMessage() {
 		$this->message  = null;
 	}
-	
+
 	//singleton protection
 	public function __clone() {
 		trigger_error('Clone is not allowed.', E_USER_ERROR);
@@ -453,7 +455,7 @@ class ShoppingCart_Controller extends Controller{
 		$request = $this->getRequest();
 		if(SecurityToken::is_enabled() && !SecurityToken::inst()->checkRequest($request)){
 			return $this->httpError(400,
-				_t("ShoppingCart.CSRF", "Invalid security token, possible CSRF attack.")
+				_t("ShoppingCart.InvalidSecurityToken", "Invalid security token, possible CSRF attack.")
 			);
 		}
 		$id = (int) $request->param('ID');
@@ -564,7 +566,7 @@ class ShoppingCart_Controller extends Controller{
 		}elseif($response = ErrorPage::response_for(404)) {
 			return $response;
 		}
-		return $this->httpError(404, _t("ShoppingCart.NOCARTINITIALISED", "no cart initialised"));
+		return $this->httpError(404, _t("ShoppingCart.NoCartInitialised", "no cart initialised"));
 	}
 
 	/**

--- a/code/checkout/Checkout.php
+++ b/code/checkout/Checkout.php
@@ -73,8 +73,8 @@ class Checkout{
 	public function setShippingAddress(Address $address) {
 		$this->order->ShippingAddressID = $address->ID;
 		if(Member::currentUserID()){
-			$this->order->MemberID = Member::currentUserID();	
-		} 
+			$this->order->MemberID = Member::currentUserID();
+		}
 		$this->order->write();
 		$this->order->extend('onSetShippingAddress', $address);
 		//update zones and userinfo
@@ -106,7 +106,7 @@ class Checkout{
 		if(!isset($methods[$paymentmethod])){
 			Session::set("Checkout.PaymentMethod", null);
 			Session::clear("Checkout.PaymentMethod");
-			return $this->error(_t("Checkout.NOPAYMENTMETHOD", "Payment method does not exist"));
+			return $this->error(_t("Checkout.NoPaymentMethod", "Payment method does not exist"));
 		}
 		Session::set("Checkout.PaymentMethod", $paymentmethod);
 		return true;

--- a/code/checkout/CheckoutComponentValidator.php
+++ b/code/checkout/CheckoutComponentValidator.php
@@ -30,7 +30,7 @@ class CheckoutComponentValidator extends RequiredFields {
 		if(!$valid){
 			$this->form->sessionMessage(
 				_t(
-					"CheckoutComponentValidator.INVALIDMESSAGE",
+					"CheckoutComponentValidator.InvalidDataMessage",
 					"There are problems with the data you entered. See below:"
 				), "bad"
 			);

--- a/code/checkout/CheckoutFieldFactory.php
+++ b/code/checkout/CheckoutFieldFactory.php
@@ -22,9 +22,9 @@ class CheckoutFieldFactory{
 
 	public function getContactFields($subset = array()) {
 		return $this->getSubset(new FieldList(
-			new TextField('FirstName', _t('CheckoutField.FIRSTNAME', 'First Name')),
-			new TextField('Surname', _t('CheckoutField.SURNAME', 'Surname')),
-			new EmailField('Email', _t('CheckoutField.EMAIL', 'Email'))
+			new TextField('FirstName', _t('Order.db_FirstName', 'First Name')),
+			new TextField('Surname', _t('Order.db_Surname', 'Surname')),
+			new EmailField('Email', _t('Order.db_Email', 'Email'))
 		), $subset);
 	}
 
@@ -45,23 +45,25 @@ class CheckoutFieldFactory{
 	}
 
 	public function getPasswordFields() {
-		$loginlink = "Security/login?BackURL=".CheckoutPage::find_link(true);
+		$loginUrl = "Security/login?BackURL=".CheckoutPage::find_link(true);
 		$fields =  new FieldList(
-			new HeaderField(_t('CheckoutField.MEMBERSHIPDETAILS', 'Membership Details'), 3),
+			new HeaderField(_t('CheckoutField.MembershipDetails', 'Membership Details'), 3),
 			new LiteralField('MemberInfo',
 				'<p class="message warning">'.
-					_t('CheckoutField.MEMBERINFO', 'If you are already a member please')
-					." <a href=\"$loginlink\">".
-						_t('OrderForm.LogIn', 'log in').
-					'</a>.'.
+					_t(
+                        'CheckoutField.MemberLoginInfo',
+                        'If you are already a member please <a href="{LoginUrl">log in</a>',
+                        '',
+                        array('LoginUrl' => $loginUrl)
+                    ) .
 				'</p>'
 			),
 			new LiteralField('AccountInfo',
-				'<p>'._t('CheckoutField.ACCOUNTINFO',
+				'<p>'._t('CheckoutField.AccountInfo',
 					'Please choose a password, so you can login and check your order history in the future'
 				).'</p>'
 			),
-			$this->getPasswordField()
+			$pwf = $this->getPasswordField()
 		);
 		if(!Checkout::user_membership_required()){
 			$pwf->setCanBeEmpty(true);
@@ -73,20 +75,20 @@ class CheckoutFieldFactory{
 		//TODO: only get one field if there is no option
 		return new OptionsetField(
 			'PaymentMethod',
-			_t('CheckoutField.PAYMENT_TYPE', "Payment Type"),
+			_t('CheckoutField.PaymentType', "Payment Type"),
 			GatewayInfo::get_supported_gateways(), array_keys(GatewayInfo::get_supported_gateways())
 		);
 	}
 
 	public function getPasswordField($confirmed = true) {
 		if($confirmed){
-			return ConfirmedPasswordField::create('Password', _t('CheckoutField.PASSWORD', 'Password'));
+			return ConfirmedPasswordField::create('Password', _t('CheckoutField.Password', 'Password'));
 		}
-		return PasswordField::create('Password', _t('CheckoutField.PASSWORD', 'Password'));
+		return PasswordField::create('Password', _t('CheckoutField.Password', 'Password'));
 	}
 
 	public function getNotesField() {
-		return TextareaField::create("Notes", _t("CheckoutField.NOTES", "Message"));
+		return TextareaField::create("Notes", _t("Order.db_Notes", "Message"));
 	}
 
 	public function getTermsConditionsField() {
@@ -96,13 +98,12 @@ class CheckoutFieldFactory{
 			$termsPage = SiteConfig::current_site_config()->TermsPage();
 
 			$field = CheckboxField::create('ReadTermsAndConditions',
-				sprintf(_t('CheckoutField.TERMSANDCONDITIONS',
-					"I agree to the terms and conditions stated on the
-						<a href=\"%s\" target=\"new\" title=\"Read the shop terms and conditions for this site\">
-							terms and conditions
-						</a>
-					page"), $termsPage->Link()
-				)
+                _t(
+                    'Checkout.TermsAndConditionsLink',
+                    'I agree to the terms and conditions stated on the <a href="{TermsPageLink}" target="new" title="Read the shop terms and conditions for this site">{TermsPageTitle}</a> page',
+                    '',
+                    array('TermsPageLink' => $termsPage->Link(), 'TermsPageTitle' => $termsPage->Title)
+                )
 			);
 		}
 

--- a/code/checkout/CheckoutForm.php
+++ b/code/checkout/CheckoutForm.php
@@ -3,7 +3,7 @@
 class CheckoutForm extends Form {
 
 	protected $config;
-	
+
 	protected $redirectlink;
 
 	public function __construct($controller, $name, CheckoutComponentConfig $config) {
@@ -12,11 +12,11 @@ class CheckoutForm extends Form {
 		$actions = new FieldList(
 			FormAction::create(
 				'checkoutSubmit',
-				_t('CheckoutForm.PROCEED', 'Proceed to payment')
+				_t('CheckoutPage.ProceedToPayment', 'Proceed to payment')
 			)
 	);
 		$validator = new CheckoutComponentValidator($this->config);
-		
+
 		// For single country sites, the Country field is readonly therefore no need to validate
 		if(SiteConfig::current_site_config()->getSingleCountry()){
 			$validator->removeRequiredField("ShippingAddressCheckoutComponent_Country");

--- a/code/checkout/CheckoutPage.php
+++ b/code/checkout/CheckoutPage.php
@@ -35,7 +35,7 @@ class CheckoutPage extends Page {
 		$fields->addFieldsToTab('Root.Main', array(
 			HtmlEditorField::create('PurchaseComplete', _t('CheckoutPage.db_PurchaseComplete', 'Purchase Complete'), 4)
 				->setDescription(
-					_t('CheckoutPage.PURCHASE_COMPLETE_DESCRIPTION',
+					_t('CheckoutPage.PurchaseCompleteDescription',
 						"This message is included in reciept email, after the customer submits the checkout")
 				)
 		), 'Metadata');
@@ -79,7 +79,7 @@ class CheckoutPage_Controller extends Page_Controller {
 			return $this->Title;
 		}
 
-		return _t('CheckoutPage.TITLE', "Checkout");
+		return _t('CheckoutPage.DefaultTitle', "Checkout");
 	}
 
 	public function OrderForm() {
@@ -124,7 +124,7 @@ class CheckoutPage_Controller extends Page_Controller {
 		$form = PaymentForm::create($this, "PaymentForm", $config);
 
 		$form->setActions(new FieldList(
-			FormAction::create("submitpayment", _t('CheckoutPage.SUBMIT_PAYMENT', "Submit Payment"))
+			FormAction::create("submitpayment", _t('CheckoutPage.SubmitPayment', "Submit Payment"))
 		));
 
 		$form->setFailureLink($this->Link());

--- a/code/checkout/OrderEmailNotifier.php
+++ b/code/checkout/OrderEmailNotifier.php
@@ -76,9 +76,11 @@ class OrderEmailNotifier {
 	 * Send customer a confirmation that the order has been received
 	 */
 	public function sendConfirmation() {
-		$subject = sprintf(
-			_t("OrderNotifier.CONFIRMATIONSUBJECT", "Order #%d Confirmation"),
-			$this->order->Reference
+		$subject = _t(
+            'ShopEmail.ConfirmationSubject',
+            'Order #{OrderNo} confirmation',
+            '',
+            array('OrderNo' => $this->order->Reference)
 		);
 		$this->sendEmail(
 			'Order_ConfirmationEmail',
@@ -91,10 +93,12 @@ class OrderEmailNotifier {
 	 * Notify store owner about new order.
 	 */
 	public function sendAdminNotification() {
-		$subject = sprintf(
-			_t("OrderNotifier.ADMINNOTIFICATIONSUBJECT", "Order #%d Notification"),
-			$this->order->Reference
-		);
+        $subject = _t(
+            'ShopEmail.AdminNotificationSubject',
+            'Order #{OrderNo} notification',
+            '',
+            array('OrderNo' => $this->order->Reference)
+        );
 
 		$this->buildEmail('Order_AdminNotificationEmail', $subject)
 			->setTo(Email::config()->admin_email)
@@ -106,10 +110,13 @@ class OrderEmailNotifier {
 	* Precondition: The order payment has been successful
 	*/
 	public function sendReceipt() {
-		$subject = sprintf(
-			_t("OrderNotifier.RECEIPTSUBJECT", "Order #%d Receipt"),
-			$this->order->Reference
-		);
+        $subject = _t(
+            'ShopEmail.ReceiptSubject',
+            'Order #{OrderNo} receipt',
+            '',
+            array('OrderNo' => $this->order->Reference)
+        );
+
 		$this->sendEmail(
 			'Order_ReceiptEmail',
 			$subject,

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -119,14 +119,14 @@ class OrderProcessor{
 	public function createPayment($gateway) {
 		if(!GatewayInfo::is_supported($gateway)) {
 			$this->error(_t(
-				"PaymentProcessor.INVALID_GATEWAY",
+				"PaymentProcessor.InvalidGateway",
 				"`{gateway}` isn't a valid payment gateway.",
 				'gateway is the name of the payment gateway',
 				array('gateway' => $gateway)));
 			return false;
 		}
 		if(!$this->order->canPay(Member::currentUser())){
-			$this->error(_t("PaymentProcessor.CANTPAY", "Order can't be paid for."));
+			$this->error(_t("PaymentProcessor.CantPay", "Order can't be paid for."));
 			return false;
 		}
 		$payment = Payment::create()
@@ -177,17 +177,17 @@ class OrderProcessor{
 	 */
 	public function canPlace(Order $order) {
 		if(!$order){
-			$this->error(_t("OrderProcessor.NULL", "Order does not exist."));
+			$this->error(_t("OrderProcessor.NoOrder", "Order does not exist."));
 			return false;
 		}
 		//order status is applicable
 		if(!$order->IsCart()){
-			$this->error(_t("OrderProcessor.NOTCART", "Order is not a cart."));
+			$this->error(_t("OrderProcessor.NotCart", "Order is not a cart."));
 			return false;
 		}
 		//order has products
 		if($order->Items()->Count() <= 0){
-			$this->error(_t("OrderProcessor.NOITEMS", "Order has no items."));
+			$this->error(_t("OrderProcessor.NoItems", "Order has no items."));
 			return false;
 		}
 
@@ -201,7 +201,7 @@ class OrderProcessor{
 	 */
 	public function placeOrder() {
 		if(!$this->order){
-			$this->error(_t("OrderProcessor.NULL", "A new order has not yet been started."));
+			$this->error(_t("OrderProcessor.NoOrderStarted", "A new order has not yet been started."));
 			return false;
 		}
 		if(!$this->canPlace($this->order)){ //final cart validation

--- a/code/checkout/components/AddressBookCheckoutComponent.php
+++ b/code/checkout/components/AddressBookCheckoutComponent.php
@@ -4,7 +4,7 @@
  * Adds the ability to use the member's address book for choosing addresses
  *
  */
-abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
+abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent implements i18nEntityProvider {
 
 	private static $composite_field_tag = 'div';
 
@@ -21,7 +21,7 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 			// group under a composite field (invisible by default) so we
 			// easily know which fields to show/hide
 			$label = _t(
-				"AddressBookCheckkoutComponent.{$this->addresstype}Address",
+				"Address.{$this->addresstype}Address",
 				"{$this->addresstype} Address"
 			);
 
@@ -44,20 +44,10 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 		$member = Member::currentUser();
 		if($member && $member->AddressBook()->exists()){
 			$addressoptions = $member->AddressBook()->sort('Created', 'DESC')->map('ID', 'toString')->toArray();
-			$addressoptions['newaddress'] = _t("AddressBookCheckoutComponent.CREATENEWADDRESS", "Create new address");
+			$addressoptions['newaddress'] = _t("Address.CreateNewAddress", "Create new address");
 			$fieldtype = count($addressoptions) > 3 ? 'DropdownField' : 'OptionsetField';
 
-			$label = '';
-			switch($this->addresstype){
-				case 'Billing':
-					$label = _t("AddressBookCheckoutComponent.EXISTING_BILLING_ADDRESS", "Existing Billing Address");
-					break;
-				case 'Shipping':
-					$label = _t("AddressBookCheckoutComponent.EXISTING_SHIPPING_ADDRESS", "Existing Shipping Address");
-					break;
-				default:
-					$label = _t("AddressBookCheckoutComponent.EXISTING_ADDRESS", "Existing Address");
-			}
+			$label = _t("Address.Existing{$this->addresstype}Address", "Existing {$this->addresstype} Address");
 
 			return new FieldList(
 				$fieldtype::create($this->addresstype."AddressID", $label,
@@ -114,7 +104,6 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -134,9 +123,32 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 			parent::setData($order, $data);
 		}
 	}
+
+    /**
+     * Provide translatable entities for this class
+     * @return array
+     */
+    public function provideI18nEntities()
+    {
+        if($this->addresstype){
+            return array(
+                "Address.{$this->addresstype}Address" => array(
+                    "{$this->addresstype} Address",
+                    "Label for the {$this->addresstype} address"
+                ),
+                "Address.Existing{$this->addresstype}Address" => array(
+                    "Existing {$this->addresstype} Address",
+                    "Label to select an existing {$this->addresstype} Address"
+                )
+            );
+        }
+
+        return array();
+    }
+
 }
 
-class ShippingAddressBookCheckoutComponent extends AddressBookCheckoutComponent{
+class ShippingAddressBookCheckoutComponent extends AddressBookCheckoutComponent {
 
 	protected $addresstype = "Shipping";
 

--- a/code/checkout/components/CustomerDetailsCheckoutComponent.php
+++ b/code/checkout/components/CustomerDetailsCheckoutComponent.php
@@ -8,9 +8,9 @@ class CustomerDetailsCheckoutComponent extends CheckoutComponent{
 
 	public function getFormFields(Order $order) {
 		$fields = new FieldList(
-			$firstname = TextField::create('FirstName', _t('CheckoutField.FIRSTNAME', 'First Name')),
-			$surname = TextField::create('Surname', _t('CheckoutField.SURNAME', 'Surname')),
-			$email = EmailField::create('Email', _t('CheckoutField.EMAIL', 'Email'))
+			$firstname = TextField::create('FirstName', _t('Order.db_FirstName', 'First Name')),
+			$surname = TextField::create('Surname', _t('Order.db_Surname', 'Surname')),
+			$email = EmailField::create('Email', _t('Order.db_Email', 'Email'))
 		);
 
 		return $fields;

--- a/code/checkout/components/MembershipCheckoutComponent.php
+++ b/code/checkout/components/MembershipCheckoutComponent.php
@@ -56,10 +56,10 @@ class MembershipCheckoutComponent extends CheckoutComponent{
 	public function getPasswordField() {
 		if($this->confirmed){
 			//relies on fix: https://github.com/silverstripe/silverstripe-framework/pull/2757
-			return ConfirmedPasswordField::create('Password', _t('CheckoutField.PASSWORD', 'Password'))
+			return ConfirmedPasswordField::create('Password', _t('CheckoutField.Password', 'Password'))
 					->setCanBeEmpty(!Checkout::membership_required());
 		}
-		return PasswordField::create('Password', _t('CheckoutField.PASSWORD', 'Password'));
+		return PasswordField::create('Password', _t('CheckoutField.Password', 'Password'));
 	}
 
 	public function validateData(Order $order, array $data) {
@@ -77,10 +77,12 @@ class MembershipCheckoutComponent extends CheckoutComponent{
 				// if a localized value exists, use this for our error-message
 				$fieldLabel = isset($fieldLabels[$idfield]) ? $fieldLabels[$idfield] : $idfield;
 				$result->error(
-					sprintf(
-						_t("Checkout.MEMBEREXISTS", "A member already exists with the %s %s"),
-						$fieldLabel, $idval
-					), $idval
+                    _t(
+                        'Checkout.MemberExists',
+                        'A member already exists with the {Field} {Identifier}',
+                        '',
+                        array('Field' => $fieldLabel, 'Identifier' => $idval)
+                    )
 				);
 			}
 			$passwordresult = $this->passwordvalidator->validate($data['Password'], $member);

--- a/code/checkout/components/NotesCheckoutComponent.php
+++ b/code/checkout/components/NotesCheckoutComponent.php
@@ -4,7 +4,7 @@ class NotesCheckoutComponent extends CheckoutComponent{
 
 	public function getFormFields(Order $order) {
 		return new FieldList(
-			TextareaField::create("Notes", _t("CheckoutField.NOTES", "Message"))
+			TextareaField::create("Notes", _t("Order.db_Notes", "Message"))
 		);
 	}
 

--- a/code/checkout/components/OnsitePaymentCheckoutComponent.php
+++ b/code/checkout/components/OnsitePaymentCheckoutComponent.php
@@ -29,7 +29,7 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 		$result = new ValidationResult();
 		//TODO: validate credit card data
 		if(!Helper::validateLuhn($data['number'])){
-			$result->error(_t('OnsitePaymentCheckoutComponent.CREDIT_CARD_INVALID','Credit card is invalid'));
+			$result->error(_t('OnsitePaymentCheckoutComponent.InvalidCreditCard','Credit card is invalid'));
 			throw new ValidationException($result);
 		}
 	}

--- a/code/checkout/components/PaymentCheckoutComponent.php
+++ b/code/checkout/components/PaymentCheckoutComponent.php
@@ -9,7 +9,7 @@ class PaymentCheckoutComponent extends CheckoutComponent{
 			$fields->push(
 				new OptionsetField(
 					'PaymentMethod',
-					_t("CheckoutFields.PAYMENTTYPE", "Payment Type"),
+					_t("CheckoutField.PaymentType", "Payment Type"),
 					$gateways,
 					array_keys($gateways)
 				)
@@ -35,12 +35,12 @@ class PaymentCheckoutComponent extends CheckoutComponent{
 	public function validateData(Order $order, array $data) {
 		$result = new ValidationResult();
 		if(!isset($data['PaymentMethod'])){
-			$result->error(_t('PaymentCheckoutComponent.NO_PAYMENT_METHOD',"Payment method not provided"), "PaymentMethod");
+			$result->error(_t('PaymentCheckoutComponent.NoPaymentMethod',"Payment method not provided"), "PaymentMethod");
 			throw new ValidationException($result);
 		}
 		$methods = GatewayInfo::get_supported_gateways();
 		if(!isset($methods[$data['PaymentMethod']])){
-			$result->error(_t('PaymentCheckoutComponent.UNSUPPORTED_GATEWAY',"Gateway not supported"), "PaymentMethod");
+			$result->error(_t('PaymentCheckoutComponent.UnsupportedGateway',"Gateway not supported"), "PaymentMethod");
 			throw new ValidationException($result);
 		}
 	}

--- a/code/checkout/components/TermsCheckoutComponent.php
+++ b/code/checkout/components/TermsCheckoutComponent.php
@@ -9,15 +9,14 @@ class TermsCheckoutComponent extends CheckoutComponent {
 		if($page->exists()) {
 			$fields->push(
 				CheckboxField::create('ReadTermsAndConditions',
-					sprintf(_t('CheckoutField.TERMSANDCONDITIONS',
-						"I agree to the terms and conditions stated on the
-							<a href=\"%s\" target=\"new\" class=\"read_terms\" title=\"Read the shop terms and conditions for this site\">
-								terms and conditions
-							</a>
-						page"), $page->Link()
-					)
+                    _t(
+                        'Checkout.TermsAndConditionsLink',
+                        'I agree to the terms and conditions stated on the <a href="{TermsPageLink}" target="new" title="Read the shop terms and conditions for this site">{TermsPageTitle}</a> page',
+                        '',
+                        array('TermsPageLink' => $page->Link(), 'TermsPageTitle' => $page->Title)
+                    )
 				)->setCustomValidationMessage(
-					_t("CheckoutField.MUSTAGREETOTERMS", "You must agree to the terms and conditions")
+					_t("CheckoutField.MustAgreeToTerms", "You must agree to the terms and conditions")
 				)
 			);
 		}

--- a/code/checkout/steps/CheckoutStep_Address.php
+++ b/code/checkout/steps/CheckoutStep_Address.php
@@ -21,7 +21,7 @@ class CheckoutStep_Address extends CheckoutStep{
 	public function shippingaddress() {
 		$form = $this->ShippingAddressForm();
 		$form->Fields()->push(new CheckboxField(
-			"SeperateBilling", _t('CheckoutStep_Address.SEPARATE_BILLING',"Bill to a different address from this")
+			"SeperateBilling", _t('CheckoutStep_Address.SeperateBilling',"Bill to a different address from this")
 		));
 		$order = $this->shippingconfig()->getOrder();
 		if($order->BillingAddressID !== $order->ShippingAddressID){
@@ -34,7 +34,7 @@ class CheckoutStep_Address extends CheckoutStep{
 	public function ShippingAddressForm() {
 		$form = new CheckoutForm($this->owner, 'ShippingAddressForm', $this->shippingconfig());
 		$form->setActions(new FieldList(
-			new FormAction("setshippingaddress", _t('CheckoutStep.CONTINUE', "Continue"))
+			new FormAction("setshippingaddress", _t('CheckoutStep.Continue', "Continue"))
 		));
 		$this->owner->extend('updateShippingAddressForm', $form);
 
@@ -69,7 +69,7 @@ class CheckoutStep_Address extends CheckoutStep{
 	public function BillingAddressForm() {
 		$form = new CheckoutForm($this->owner, 'BillingAddressForm', $this->billingconfig());
 		$form->setActions(new FieldList(
-			new FormAction("setbillingaddress", _t('CheckoutStep.CONTINUE', "Continue"))
+			new FormAction("setbillingaddress", _t('CheckoutStep.Continue', "Continue"))
 		));
 		$this->owner->extend('updateBillingAddressForm', $form);
 

--- a/code/checkout/steps/CheckoutStep_ContactDetails.php
+++ b/code/checkout/steps/CheckoutStep_ContactDetails.php
@@ -34,7 +34,7 @@ class CheckoutStep_ContactDetails extends CheckoutStep{
 		$form = new CheckoutForm($this->owner, 'ContactDetailsForm', $config);
 		$form->setRedirectLink($this->NextStepLink());
 		$form->setActions(new FieldList(
-			new FormAction("checkoutSubmit", _t('CheckoutStep.CONTINUE', "Continue"))
+			new FormAction("checkoutSubmit", _t('CheckoutStep.Continue', "Continue"))
 		));
 		$this->owner->extend('updateContactDetailsForm', $form);
 

--- a/code/checkout/steps/CheckoutStep_Membership.php
+++ b/code/checkout/steps/CheckoutStep_Membership.php
@@ -36,8 +36,8 @@ class CheckoutStep_Membership extends CheckoutStep{
 		$fields = new FieldList();
 		$actions = new FieldList(
 			new FormAction("createaccount",
-				_t('CheckoutStep_Membership.CREATE_ACCOUNT', "Create an Account", 'This is an option presented to the user')),
-			new FormAction("guestcontinue", _t('CheckoutStep_Membership.CONTINUE_AS_GUEST', "Continue as Guest"))
+				_t('CheckoutStep_Membership.CreateAccount', "Create an Account", 'This is an option presented to the user')),
+			new FormAction("guestcontinue", _t('CheckoutStep_Membership.ContinueAsGuest', "Continue as Guest"))
 		);
 		$form = Form::create($this->owner, 'MembershipForm', $fields, $actions);
 		$this->owner->extend('updateMembershipForm', $form);
@@ -87,7 +87,7 @@ class CheckoutStep_Membership extends CheckoutStep{
 		$form = new CheckoutForm($this->owner, "CreateAccountForm", $this->registerconfig());
 		$form->setActions(new FieldList(
 			new FormAction('docreateaccount',
-				_t('CheckoutStep_Membership.CREATE_NEW_ACCOUNT', 'Create New Account', 'This is an action (Button label)'))
+				_t('CheckoutStep_Membership.CreateNewAccount', 'Create New Account', 'This is an action (Button label)'))
 		));
 		$form->getValidator()->addRequiredField("Password");
 

--- a/code/checkout/steps/CheckoutStep_PaymentMethod.php
+++ b/code/checkout/steps/CheckoutStep_PaymentMethod.php
@@ -27,7 +27,7 @@ class CheckoutStep_PaymentMethod extends CheckoutStep{
 	public function PaymentMethodForm() {
 		$form = new CheckoutForm($this->owner, "PaymentMethodForm", $this->checkoutconfig());
 		$form->setActions(new FieldList(
-			FormAction::create("setpaymentmethod",  _t('CheckoutStep.CONTINUE', "Continue"))
+			FormAction::create("setpaymentmethod",  _t('CheckoutStep.Continue', "Continue"))
 		));
 		$this->owner->extend('updatePaymentMethodForm', $form);
 

--- a/code/cms/OrdersAdmin.php
+++ b/code/cms/OrdersAdmin.php
@@ -73,7 +73,7 @@ class OrderGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemReque
 		'ItemEditForm',
 		'printorder'
 	);
-	
+
 	/**
 	 * Add print button to order detail form
 	 */
@@ -85,7 +85,7 @@ class OrderGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemReque
 JS;
 		$form->Actions()->push(
 			new LiteralField("PrintOrder",
-				"<button class=\"no-ajax grid-print-button\" data-icon=\"grid_print\" onclick=\"javascript:$printwindowjs\">"._t("Order.PRINT","Print")."</button>"
+				"<button class=\"no-ajax grid-print-button\" data-icon=\"grid_print\" onclick=\"javascript:$printwindowjs\">"._t("Order.Print","Print")."</button>"
 			)
 		);
 
@@ -101,11 +101,11 @@ JS;
 		if(isset($_REQUEST['print']) && $_REQUEST['print']) {
 			Requirements::customScript("if(document.location.href.indexOf('print=1') > 0) {window.print();}");
 		}
-		$title = i18n::_t("ORDER.INVOICE","Invoice");
+		$title = i18n::_t("Order.Invoice","Invoice");
 		if($id = $this->popupController->getRequest()->param('ID')) {
 			$title .= " #$id";
 		}
-		
+
 		return $this->record->customise(array(
 			'SiteConfig' => SiteConfig::current_site_config(),
 			'Title' => $title

--- a/code/cms/ShopConfig.php
+++ b/code/cms/ShopConfig.php
@@ -28,21 +28,21 @@ class ShopConfig extends DataExtension {
 		$fields->addFieldsToTab("Root.Shop", new TabSet("ShopTabs",
 			$maintab = new Tab("Main",
 				TreeDropdownField::create('TermsPageID',
-					_t("ShopConfig.TERMSPAGE", 'Terms and Conditions Page'),
+					_t("ShopConfig.TermsPage", 'Terms and Conditions Page'),
 				'SiteTree'),
 				TreeDropdownField::create("CustomerGroupID",
-					_t("ShopConfig.CUSTOMERGROUP", "Group to add new customers to"),
+					_t("ShopConfig.CustomerGroup", "Group to add new customers to"),
 				"Group"),
-				UploadField::create('DefaultProductImage', _t('ShopConfig.DEFAULTIMAGE', 'Default Product Image'))
+				UploadField::create('DefaultProductImage', _t('ShopConfig.DefaultImage', 'Default Product Image'))
 			),
 			$countriestab = new Tab("Countries",
-				CheckboxSetField::create('AllowedCountries', _t('ShopConfig.ALLOWED_COUNTRIES', 'Allowed Ordering and Shipping Countries'),
+				CheckboxSetField::create('AllowedCountries', _t('ShopConfig.AllowedCountries', 'Allowed Ordering and Shipping Countries'),
 					self::config()->iso_3166_country_codes
 				)
 			)
 		));
 		$fields->removeByName("CreateTopLevelGroups");
-		$countriestab->setTitle(_t('ShopConfig.ALLOWED_COUNTRIES_TAB_TITLE', "Allowed Countries"));
+		$countriestab->setTitle(_t('ShopConfig.AllowedCountriesTabTitle', "Allowed Countries"));
 	}
 
 	public static function get_base_currency() {

--- a/code/cms/dashboard/DashboardRecentMembersPanel.php
+++ b/code/cms/dashboard/DashboardRecentMembersPanel.php
@@ -28,7 +28,7 @@ if (class_exists('DashboardPanel')) {
 
 		public function getConfiguration() {
 			$fields = parent::getConfiguration();
-			$fields->push(TextField::create("Count", _t('ShopDashboard.NUMBER_OF_ACCOUNTS', "Number of accounts to show")));
+			$fields->push(TextField::create("Count", _t('ShopDashboard.NumberOfAccounts', "Number of accounts to show")));
 			return $fields;
 		}
 

--- a/code/cms/dashboard/DashboardRecentOrdersChart.php
+++ b/code/cms/dashboard/DashboardRecentOrdersChart.php
@@ -26,7 +26,7 @@ if (class_exists('DashboardPanel')) {
 
 		public function getConfiguration() {
 			$fields = parent::getConfiguration();
-			$fields->push(TextField::create("Days", _t('ShopDashboard.NUMBER_OF_DAYS', "Number of days to show")));
+			$fields->push(TextField::create("Days", _t('ShopDashboard.NumberOfDays', "Number of days to show")));
 			return $fields;
 		}
 

--- a/code/cms/dashboard/DashboardRecentOrdersPanel.php
+++ b/code/cms/dashboard/DashboardRecentOrdersPanel.php
@@ -17,18 +17,18 @@ if (class_exists('DashboardPanel')) {
 
 
 		public function getLabel() {
-			return _t('ShopDashboard.RECENTORDERS', 'Recent Orders');
+			return _t('ShopDashboard.RecentOrders', 'Recent Orders');
 		}
 
 
 		public function getDescription() {
-			return _t('ShopDashboard.RECENTORDERSDESCRIPTION', 'Shows recent orders');
+			return _t('ShopDashboard.RecentOrdersDescription', 'Shows recent orders');
 		}
 
 
 		public function getConfiguration() {
 			$fields = parent::getConfiguration();
-			$fields->push(TextField::create("Count", _t('ShopDashboard.NUMBER_OF_ORDERS', "Number of orders to show")));
+			$fields->push(TextField::create("Count", _t('ShopDashboard.NumberOfOrders', "Number of orders to show")));
 			return $fields;
 		}
 

--- a/code/dev/ShopDevelopmentAdmin.php
+++ b/code/dev/ShopDevelopmentAdmin.php
@@ -37,7 +37,7 @@ class ShopDevelopmentAdmin extends Controller{
 		//render the debug view
 		$renderer = Object::create('DebugView');
 		$renderer->writeHeader();
-		$renderer->writeInfo(_t("Shop.DEVTOOLSTITLE", "Shop Development Tools"), Director::absoluteBaseURL());
+		$renderer->writeInfo(_t("Shop.DevToolsTitle", "Shop Development Tools"), Director::absoluteBaseURL());
 
 	}
 

--- a/code/model/Address.php
+++ b/code/model/Address.php
@@ -64,25 +64,25 @@ class Address extends DataObject{
 			$this->getCountryField(), 'State'
 		);
 		$fields->removeByName("MemberID");
-		
+
 		return $fields;
 	}
 
 	public function getFrontEndFields($params = null) {
 		$fields = new FieldList(
 			$this->getCountryField(),
-			$addressfield = TextField::create('Address', _t('Address.ADDRESS', 'Address')),
-			$address2field = TextField::create('AddressLine2', _t('Address.ADDRESSLINE2', 'Address Line 2 (optional)')),
-			$cityfield = TextField::create('City', _t('Address.CITY', 'City')),
-			$statefield = TextField::create('State', _t('Address.STATE', 'State')),
-			$postcodefield = TextField::create('PostalCode', _t('Address.POSTALCODE', 'Postal Code')),
-			$phonefield = TextField::create('Phone', _t('Address.PHONE', 'Phone Number'))
+			$addressfield = TextField::create('Address', _t('Address.db_Address', 'Address')),
+			$address2field = TextField::create('AddressLine2', _t('Address.db_AddressLine2', 'Address Line 2 (optional)')),
+			$cityfield = TextField::create('City', _t('Address.db_City', 'City')),
+			$statefield = TextField::create('State', _t('Address.db_State', 'State')),
+			$postcodefield = TextField::create('PostalCode', _t('Address.db_PostalCode', 'Postal Code')),
+			$phonefield = TextField::create('Phone', _t('Address.db_Phone', 'Phone Number'))
 		);
 		if(isset($params['addfielddescriptions']) && !empty($params['addfielddescriptions'])){
-			$addressfield->setDescription(_t("Address.ADDRESSHINT", "street / thoroughfare number, name, and type or P.O. Box"));
-			$address2field->setDescription(_t("Address.ADDRESS2HINT", "premises, building, apartment, unit, floor"));
-			$cityfield->setDescription(_t("Address.CITYHINT", "or suburb, county, district"));
-			$statefield->setDescription(_t("Address.STATEHINT", "or province, territory, island"));
+			$addressfield->setDescription(_t("Address.AddressHint", "street / thoroughfare number, name, and type or P.O. Box"));
+			$address2field->setDescription(_t("Address.AddressLine2Hint", "premises, building, apartment, unit, floor"));
+			$cityfield->setDescription(_t("Address.CityHint", "or suburb, county, district"));
+			$statefield->setDescription(_t("Address.StateHint", "or province, territory, island"));
 		}
 
 		$this->extend('updateFormFields', $fields);
@@ -94,12 +94,12 @@ class Address extends DataObject{
 		if(count($countries) == 1){
 			//field name is Country_readonly so it's value doesn't get updated
 			return new ReadonlyField("Country_readonly",
-				_t('Address.COUNTRY', 'Country'),
+				_t('Address.db_Country', 'Country'),
 				array_pop($countries)
 			);
 		}
 		$field = DropdownField::create("Country",
-			_t('Address.COUNTRY', 'Country'),
+			_t('Address.db_Country', 'Country'),
 			$countries
 		)->setHasEmptyDefault(true);
 

--- a/code/model/Order.php
+++ b/code/model/Order.php
@@ -148,8 +148,12 @@ class Order extends DataObject {
 	private static $allow_zero_order_total = false;
 
 	public static function get_order_status_options() {
-		return singleton('Order')->dbObject('Status')->enumValues(false);
-	}
+        $values = array();
+        foreach(singleton('Order')->dbObject('Status')->enumValues(false) as $value){
+            $values[$value] = _t('Order.STATUS_' . strtoupper($value), $value);
+        }
+        return $values;
+    }
 
 	/**
 	 * Create CMS fields for cms viewing and editing orders
@@ -194,9 +198,9 @@ class Order extends DataObject {
 				->setMultiple(true)
 		);
 		//add date range filtering
-		$fields->insertBefore(DateField::create("DateFrom", _t('Order.DATE_FROM', "Date from"))
+		$fields->insertBefore(DateField::create("DateFrom", _t('Order.DateFrom', "Date from"))
 			->setConfig('showcalendar', true), 'Status');
-		$fields->insertBefore(DateField::create("DateTo", _t('Order.DATE_TO', "Date to"))
+		$fields->insertBefore(DateField::create("DateTo", _t('Order.DateTo', "Date to"))
 			->setConfig('showcalendar', true), 'Status');
 		//get the array, to maniplulate name, and fullname seperately
 		$filters = $context->getFilters();
@@ -287,7 +291,15 @@ class Order extends DataObject {
 		);
 	}
 
-	/**
+    /**
+     * Get the order status. This will return a localized value if available.
+     * @return string the payment status
+     */
+    public function getStatusI18N() {
+        return _t('Order.STATUS_' . strtoupper($this->Status), $this->Status);
+    }
+
+    /**
 	 * Get the link for finishing order processing.
 	 */
 	public function Link() {
@@ -529,5 +541,26 @@ class Order extends DataObject {
 
 		return $val;
 	}
+
+    /**
+     * Provide i18n entities for the order class
+     * @return array
+     */
+    public function provideI18nEntities()
+    {
+        $entities = parent::provideI18nEntities();
+
+        // collect all the payment status values
+        foreach($this->dbObject('Status')->enumValues() as $value){
+            $key = strtoupper($value);
+            $entities["Order.STATUS_$key"] = array(
+                $value,
+                "Translation of the order status '$value'"
+            );
+        }
+
+        return $entities;
+    }
+
 
 }

--- a/code/model/ShopMember.php
+++ b/code/model/ShopMember.php
@@ -31,7 +31,7 @@ class ShopMember extends DataExtension {
 		$fields->removeByName("DefaultShippingAddressID");
 		$fields->removeByName("DefaultBillingAddressID");
 		$fields->addFieldToTab('Root.Main',
-			new DropdownField('Country', _t('Address.COUNTRY', 'Country'),
+			new DropdownField('Country', _t('Address.db_Country', 'Country'),
 				SiteConfig::current_site_config()->getCountriesList()
 			)
 		);

--- a/code/model/fieldtypes/CanBeFreeCurrency.php
+++ b/code/model/fieldtypes/CanBeFreeCurrency.php
@@ -7,7 +7,7 @@ class CanBeFreeCurrency extends Currency{
 
 	public function Nice(){
 		if($this->value == 0){
-			return _t("ShopCurrency.FREE","<span class=\"free\">FREE</span>");
+			return _t("ShopCurrency.Free","<span class=\"free\">FREE</span>");
 		}
 		return parent::Nice();
 	}

--- a/code/model/fieldtypes/I18nDatetime.php
+++ b/code/model/fieldtypes/I18nDatetime.php
@@ -12,12 +12,12 @@ class I18nDatetime extends SS_Datetime{
 	 * locale sould be set
 	 */
 	public function Nice() {
-		if($this->value) return $this->FormatI18N(_t('General.DATETIMEFORMATNICE','%m/%d/%G %I:%M%p'));
+		if($this->value) return $this->FormatI18N(_t('Shop.DateTimeFormatNice','%m/%d/%G %I:%M%p'));
 	}
 	public function NiceDate() {
-		if($this->value) return $this->FormatI18N(_t('General.DATEFORMATNICE','%m/%d/%G'));
+		if($this->value) return $this->FormatI18N(_t('Shop.DateFormatNice','%m/%d/%G'));
 	}
 	public function Nice24() {
-		return date(_t('General.DATETIMEFORMATNICE24','d/m/Y H:i'), strtotime($this->value));
+		return date(_t('Shop.DateTimeFormatNice24','d/m/Y H:i'), strtotime($this->value));
 	}
 }

--- a/code/modifiers/shipping/FreeShippingModifier.php
+++ b/code/modifiers/shipping/FreeShippingModifier.php
@@ -10,7 +10,7 @@ class FreeShippingModifier extends ShippingModifier{
 	}
 
 	public function TableValue() {
-		return _t("FreeShippingModifier.FREE", "FREE");
+		return _t("FreeShippingModifier.Free", "FREE");
 	}
 
 }

--- a/code/modifiers/shipping/SimpleShippingModifier.php
+++ b/code/modifiers/shipping/SimpleShippingModifier.php
@@ -25,7 +25,12 @@ class SimpleShippingModifier extends ShippingModifier {
 	public function TableTitle() {
 		if($country = $this->Country()) {
 			$countryList = SiteConfig::current_site_config()->getCountriesList();
-			return sprintf(_t("SimpleShippingModifier.SHIPTO","Ship to %s"),$countryList[$country]);
+            return _t(
+                'SimpleShippingModifier.ShipToCountry',
+                'Ship to {Country}',
+                '',
+                array('Country' => $countryList[$country])
+            );
 		} else {
 			return parent::TableTitle();
 		}

--- a/code/modifiers/shipping/WeightShippingModifier.php
+++ b/code/modifiers/shipping/WeightShippingModifier.php
@@ -42,7 +42,12 @@ class WeightShippingModifier extends ShippingModifier {
 	}
 
 	public function TableTitle(){
-		return  sprintf(_t("WeightShippingModifier.TABLETITLE","Shipping (%f kg)"),$this->Weight());
+        return _t(
+            'WeightShippingModifier.TableTitle',
+            'Shipping ({Kilograms} kg)',
+            '',
+            array('Kilograms' => $this->Weight())
+        );
 	}
 
 	/**

--- a/code/modifiers/tax/GlobalTaxModifier.php
+++ b/code/modifiers/tax/GlobalTaxModifier.php
@@ -33,7 +33,7 @@ class GlobalTaxModifier extends TaxModifier {
 	public function TableTitle() {
 		$country = $this->Country ? " for ".$this->Country." " : "";
 		return parent::TableTitle().$country.
-			($this->Type == "Chargable" ? '' : _t("GlobalTaxModifier.INCLUDED",' (included in the above price)'));
+			($this->Type == "Chargable" ? '' : _t("GlobalTaxModifier.Included",' (included in the above price)'));
 	}
 
 }

--- a/code/modifiers/tax/TaxModifier.php
+++ b/code/modifiers/tax/TaxModifier.php
@@ -19,7 +19,12 @@ class TaxModifier extends OrderModifier{
 	public function TableTitle(){
 		$title =  parent::TableTitle();
 		if($this->Rate)
-			$title .= " ".sprintf(_t("TaxModifier.ATRATE","@ %s"),number_format($this->Rate * 100, 1)."%");
+			$title .= ' ' . _t(
+                'TaxModifier.AtRate',
+                '@ {Rate}%',
+                '',
+                array('Rate' => number_format($this->Rate * 100, 1))
+            );
 		return $title;
 	}
 

--- a/code/product/AddProductForm.php
+++ b/code/product/AddProductForm.php
@@ -59,7 +59,7 @@ class AddProductForm extends Form {
 			}
 
 			$this->extend('updateAddToCart', $form, $buyable);
-			
+
 			$request = $this->getRequest();
 			$this->extend('updateAddProductFormResponse', $request, $response, $buyable, $quantity, $form);
 
@@ -89,10 +89,10 @@ class AddProductForm extends Form {
 				$count++;
 			}
 
-			$fields->push(new DropdownField('Quantity', _t('AddProductForm.Quantity', 'Quantity'), $values, 1));
+			$fields->push(new DropdownField('Quantity', _t('Shop.Quantity', 'Quantity'), $values, 1));
 		} else {
 			$fields->push(
-				NumericField::create(_t('AddProductForm.Quantity', 'Quantity'), 'Quantity', 1)
+				NumericField::create(_t('Shop.Quantity', 'Quantity'), 'Quantity', 1)
 					->setAttribute('type','number')
 					->setAttribute('min', '0')
 			);
@@ -106,7 +106,7 @@ class AddProductForm extends Form {
 	 */
 	protected function getFormActions(){
 		return new FieldList(
-			new FormAction('addtocart',_t("AddProductForm.ADDTOCART",'Add to Cart'))
+			new FormAction('addtocart',_t("Product.AddToCart",'Add to Cart'))
 		);
 	}
 

--- a/code/product/Product.php
+++ b/code/product/Product.php
@@ -100,38 +100,42 @@ class Product extends Page implements Buyable {
 		self::disableCMSFieldsExtensions();
 		$fields = parent::getCMSFields();
 		$fields->fieldByName('Root.Main.Title')
-			->setTitle(_t('Product.PAGETITLE', 'Product Title'));
+			->setTitle(_t('Product.PageTitle', 'Product Title'));
 		//general fields
 		$fields->addFieldsToTab('Root.Main', array(
-			TextField::create('InternalItemID', _t('Product.CODE', 'Product Code/SKU'), '', 30),
-			DropdownField::create('ParentID', _t("Product.CATEGORY", "Category"), $this->getCategoryOptions())
-				->setDescription(_t("Product.CATEGORYDESCRIPTION", "This is the parent page or default category.")),
-			ListBoxField::create('ProductCategories', _t("Product.ADDITIONALCATEGORIES", "Additional Categories"),
+			TextField::create('InternalItemID', _t('Product.InternalItemID', 'Product Code/SKU'), '', 30),
+			DropdownField::create('ParentID', _t("Product.Category", "Category"), $this->getCategoryOptions())
+				->setDescription(_t("Product.CategoryDescription", "This is the parent page or default category.")),
+			ListBoxField::create('ProductCategories', _t("Product.AdditionalCategories", "Additional Categories"),
 					$this->getCategoryOptionsNoParent()
 				)->setMultiple(true),
-			TextField::create('Model', _t('Product.MODEL', 'Model'), '', 30),
-			CheckboxField::create('Featured', _t('Product.FEATURED', 'Featured Product')),
-			CheckboxField::create('AllowPurchase', _t('Product.ALLOWPURCHASE', 'Allow product to be purchased'), 1)
+			TextField::create('Model', _t('Product.Model', 'Model'), '', 30),
+			CheckboxField::create('Featured', _t('Product.Featured', 'Featured Product')),
+			CheckboxField::create('AllowPurchase', _t('Product.AllowPurchase', 'Allow product to be purchased'), 1)
 		), 'Content');
 		//pricing
 		$fields->addFieldsToTab('Root.Pricing', array(
-			TextField::create('BasePrice', _t('Product.PRICE', 'Price'))
-				->setDescription(_t('Product.PRICEDESC', "Base price to sell this product at."))
+			TextField::create('BasePrice', _t('Product.db_BasePrice', 'Price'))
+				->setDescription(_t('Product.PriceDesc', "Base price to sell this product at."))
 				->setMaxLength(12),
-			TextField::create('CostPrice', _t('Product.COSTPRICE', 'Cost Price'))
-				->setDescription(_t('Product.COSTPRICEDESC', 'Wholesale price before markup.'))
+			TextField::create('CostPrice', _t('Product.db_CostPrice', 'Cost Price'))
+				->setDescription(_t('Product.CostPriceDescription', 'Wholesale price before markup.'))
 				->setMaxLength(12)
 		));
 		//physical measurements
+        $fieldSubstitutes = array(
+            'LengthUnit' => self::config()->length_unit,
+            'WeightUnit' => self::config()->weight_unit
+        );
 		$fields->addFieldsToTab('Root.Shipping', array(
-			TextField::create('Weight', sprintf(_t('Product.WEIGHT', 'Weight (%s)'), self::config()->weight_unit), '', 12),
-			TextField::create('Height', sprintf(_t('Product.HEIGHT', 'Height (%s)'), self::config()->length_unit), '', 12),
-			TextField::create('Width', sprintf(_t('Product.WIDTH', 'Width (%s)'), self::config()->length_unit), '', 12),
-			TextField::create('Depth', sprintf(_t('Product.DEPTH', 'Depth (%s)'), self::config()->length_unit), '', 12),
+			TextField::create('Weight', _t('Product.WeightWithUnit', 'Weight ({WeightUnit})', '', $fieldSubstitutes), '', 12),
+			TextField::create('Height', _t('Product.HeightWithUnit', 'Height ({LengthUnit})', '', $fieldSubstitutes), '', 12),
+			TextField::create('Width', _t('Product.WidthWithUnit', 'Width ({LengthUnit})', '', $fieldSubstitutes), '', 12),
+			TextField::create('Depth', _t('Product.DepthWithUnit', 'Depth ({LengthUnit})', '', $fieldSubstitutes), '', 12),
 		));
 		if(!$fields->dataFieldByName('Image')) {
 			$fields->addFieldToTab('Root.Images',
-				UploadField::create('Image', _t('Product.IMAGE', 'Product Image'))
+				UploadField::create('Image', _t('Product.Image', 'Product Image'))
 			);
 		}
 		self::enableCMSFieldsExtensions();

--- a/code/product/variations/ProductAttributeType.php
+++ b/code/product/variations/ProductAttributeType.php
@@ -62,7 +62,7 @@ class ProductAttributeType extends DataObject{
 		}else{
 			$fields->push(LiteralField::create("Values",
 				'<p class="message warning">' .
-					_t('ProductAttributeType.SAVE_FIRST_MESSAGE', 'Save first, then you can add values.') .
+					_t('ProductAttributeType.SaveFirstInfo', 'Save first, then you can add values.') .
 				'</p>'
 			));
 		}

--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -73,8 +73,8 @@ class ProductVariation extends DataObject implements Buyable {
 
 	public function getCMSFields() {
 		$fields = new FieldList(
-			TextField::create('InternalItemID', _t('Product.CODE', 'Product Code')),
-			TextField::create('Price', _t('Product.PRICE', 'Price'))
+			TextField::create('InternalItemID', _t('Product.Code', 'Product Code')),
+			TextField::create('Price', _t('Product.db_BasePrice', 'Price'))
 		);
 		//add attributes dropdowns
 		$attributes = $this->Product()->VariationAttributeTypes();
@@ -89,7 +89,7 @@ class ProductVariation extends DataObject implements Buyable {
 					$fields->push(LiteralField::create('novalues'.$attribute->Name,
 						'<p class="message warning">'.
 							_t(
-								'ProductVariation.NO_ATTRIBUTE_VALUES_MESSAGE',
+								'ProductVariation.NoAttributeValuesMessage',
 								'{attribute} has no values to choose from. You can create them in the "Products" &#62; "Product Attribute Type" section of the CMS.',
 								'Warning that will be shown if an attribute doesn\'t have any values',
 								array('attribute' => $attribute->Name)
@@ -103,14 +103,14 @@ class ProductVariation extends DataObject implements Buyable {
 			$fields->push(LiteralField::create('savefirst',
 				'<p class="message warning">'.
 					_t(
-						'ProductVariation.SAVE_FIRST_MESSAGE',
+						'ProductVariation.MustSaveFirstMessage',
 						"You can choose variation attributes after saving for the first time, if they exist."
 					) .
 				'</p>'
 			));
 		}
 		$fields->push(
-			UploadField::create('Image', _t('Product.IMAGE', 'Product Image'))
+			UploadField::create('Image', _t('Product.Image', 'Product Image'))
 		);
 		$this->extend('updateCMSFields', $fields);
 

--- a/code/product/variations/ProductVariationsExtension.php
+++ b/code/product/variations/ProductVariationsExtension.php
@@ -20,14 +20,14 @@ class ProductVariationsExtension extends DataExtension {
 	 */
 	public function updateCMSFields(FieldList $fields) {
 		$fields->addFieldsToTab('Root.Variations',array(
-			ListboxField::create("VariationAttributeTypes", _t('ProductVariationsExtension.ATTRIBUTES', "Attributes"),
+			ListboxField::create("VariationAttributeTypes", _t('ProductVariationsExtension.Attributes', "Attributes"),
 				ProductAttributeType::get()->map("ID", "Title")->toArray()
 			)->setMultiple(true)
 			->setDescription(_t(
-				'ProductVariationsExtension.ATTRIBUTES_DESCRIPTION',
+				'ProductVariationsExtension.AttributesDescription',
 				"These are fields to indicate the way(s) each variation varies. Once selected, they can be edited on each variation."
 			)),
-			GridField::create("Variations", _t('ProductVariationsExtension.VARIATIONS', "Variations"),
+			GridField::create("Variations", _t('ProductVariationsExtension.Variations', "Variations"),
 				$this->owner->Variations(),
 				GridFieldConfig_RecordEditor::create()
 			)
@@ -35,7 +35,7 @@ class ProductVariationsExtension extends DataExtension {
 		if($this->owner->Variations()->exists()) {
 			$fields->addFieldToTab('Root.Pricing',
 				LabelField::create('variationspriceinstructinos', _t(
-					'ProductVariationsExtension.VARIATIONS_INSTRUCTIONS',
+					'ProductVariationsExtension.VariationsInfo',
 					"Price - Because you have one or more variations, the price can be set in the \"Variations\" tab."
 				))
 			);

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -18,7 +18,7 @@ class VariationForm extends AddProductForm {
 		foreach($attributes as $attribute){
 			$farray[] = $attribute->getDropDownField(
 				_t(
-					'VariationForm.CHOOSE_ATTRIBUTE',
+					'VariationForm.ChooseAttribute',
 					"Choose {attribute} …",
 					'',
 					array('attribute' => $attribute->Label)
@@ -96,7 +96,7 @@ class VariationForm extends AddProductForm {
 
 			if($cart->add($variation, $quantity)) {
 				$form->sessionMessage(
-					_t('ShoppingCart.ITEMADD', "Item has been added successfully."),
+					_t('ShoppingCart.ItemAdded', "Item has been added successfully."),
 					"good"
 				);
 			} else {
@@ -105,7 +105,7 @@ class VariationForm extends AddProductForm {
 		} else {
 			$variation = null;
 			$form->sessionMessage(
-				_t('VariationForm.VARIATION_NOT_AVAILABLE', "That variation is not available, sorry."),
+				_t('VariationForm.VariationNotAvailable', "That variation is not available, sorry."),
 				"bad"
 			); //validation fail
 		}

--- a/code/product/variations/VariationFormValidator.php
+++ b/code/product/variations/VariationFormValidator.php
@@ -12,7 +12,7 @@ class VariationFormValidator extends RequiredFields {
 		if($valid && !$this->form->getBuyable($_POST)) {
 			$this->validationError(
 				"",
-				_t('VariationForm.PRODUCT_NOT_AVAILABLE', "This product is not available with the selected options.")
+				_t('VariationForm.ProductNotAvailable', "This product is not available with the selected options.")
 			);
 
 			$valid = false;

--- a/code/reports/ShopPeriodReport.php
+++ b/code/reports/ShopPeriodReport.php
@@ -3,7 +3,7 @@
  * Base class for creating reports that can be filtered to a specific range.
  * Record grouping is also supported.
  */
-class ShopPeriodReport extends SS_Report{
+class ShopPeriodReport extends SS_Report implements i18nEntityProvider {
 
 	private static $display_uncategorised_data = false;
 
@@ -19,11 +19,11 @@ class ShopPeriodReport extends SS_Report{
 	);
 
 	public function title(){
-		return _t($this->class.".TITLE",$this->title);
+		return _t($this->class.".Title",$this->title);
 	}
 
 	public function description(){
-		return _t($this->class.".DESCRIPTION",$this->description);
+		return _t($this->class.".Description",$this->description);
 	}
 
 	public function parameterFields() {
@@ -134,13 +134,31 @@ class ShopPeriodReport extends SS_Report{
 			}
 		}
 		$query->setOrderBy("\"FilterPeriod\"","ASC");
-	
+
 		return $query;
 	}
 
 	protected function fd($date, $format){
 		return DB::getConn()->formattedDatetimeClause($date, $format);
 	}
+
+    /**
+     * Provide translatable entities for this class and all subclasses
+     * @return array
+     */
+    public function provideI18nEntities()
+    {
+        return array(
+            "{$this->class}.Title" => array(
+                $this->title,
+                "Title for the {$this->class} report"
+            ),
+            "{$this->class}.Description" => array(
+                $this->description,
+                "Description for the {$this->class} report"
+            )
+        );
+    }
 
 }
 

--- a/code/reports/ShopSideReport.php
+++ b/code/reports/ShopSideReport.php
@@ -11,11 +11,11 @@
 class ShopSideReport_FeaturedProducts extends SS_Report {
 
 	public function title() {
-		return _t('ShopSideReport.FEATUREDPRODUCTS', "Featured Products");
+		return _t('ShopSideReport.FeaturedProducts', "Featured Products");
 	}
 
 	public function group() {
-		return _t('ShopSideReport.ShopGROUP', "Shop");
+		return _t('ShopSideReport.ShopGroup', "Shop");
 	}
 
 	public function sort() {
@@ -43,11 +43,11 @@ class ShopSideReport_FeaturedProducts extends SS_Report {
 class ShopSideReport_AllProducts extends SS_Report {
 
 	public function title() {
-		return _t('ShopSideReport.ALLPRODUCTS', "All Products");
+		return _t('ShopSideReport.AllProducts', "All Products");
 	}
 
 	public function group() {
-		return _t('ShopSideReport.ShopGROUP', "Shop");
+		return _t('ShopSideReport.ShopGroup', "Shop");
 	}
 	public function sort() {
 		return 0;
@@ -71,10 +71,10 @@ class ShopSideReport_AllProducts extends SS_Report {
 class ShopSideReport_NoImageProducts extends SS_Report {
 
 	public function title() {
-		return _t('ShopSideReport.NOIMAGE',"Products with no image");
+		return _t('ShopSideReport.NoImage',"Products with no image");
 	}
 	public function group() {
-		return _t('ShopSideReport.ShopGROUP', "Shop");
+		return _t('ShopSideReport.ShopGroup', "Shop");
 	}
 	public function sort() {
 		return 0;
@@ -95,10 +95,10 @@ class ShopSideReport_NoImageProducts extends SS_Report {
 class ShopSideReport_HeavyProducts extends SS_Report {
 
 	public function title() {
-		return _t('ShopSideReport.HEAVY',"Heavy Products");
+		return _t('ShopSideReport.Heavy',"Heavy Products");
 	}
 	public function group() {
-		return _t('ShopSideReport.ShopGROUP', "Shop");
+		return _t('ShopSideReport.ShopGroup', "Shop");
 	}
 	public function sort() {
 		return 0;

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,521 +1,289 @@
----
 en:
-  AccountNavigation:
-    AddressBook: "Address Book"
-    EditProfile: "Edit Profile"
-    LogOut: "Log Out"
-    MemberEmail: Email
-    MemberLastVisit: "Last Visit"
-    MemberName: Name
-    MemberSince: "Member Since"
-    NumberOfOrders: "Number of orders"
-    PastOrders: "Past Orders"
-    Title: "My Account"
+  OrdersAdmin:
+    MENUTITLE: Orders
+  ProductCatalogAdmin:
+    MENUTITLE: Catalog
+  ZoneAdmin:
+    MENUTITLE: Zones
+  AbandonedCartReport:
+    Description: 'Monitor abandoned carts for a particular period. Group results by year, month, or day.'
+    Title: 'Abandoned Carts'
   AccountPage:
-    DESCRIPTION: "Generic content page"
-    LOGIN: "You'll need to login before you can access the account page. If you are not registered, you won't be able to access it until you make your first order, otherwise please enter your details below."
-    LOGINAGAIN: "You have been logged out. If you would like to log in again, please do so below."
-    Message: "You'll need to login before you can access the account page. If you are not registered, you won't be able to access it until you make your first order, otherwise please enter your details below."
-    NOPAGE: "No AccountPage on this site - please create one !"
-    NoPastOrders: "No past orders found."
-    PLURALNAME: "Account Pages"
-    SINGULARNAME: "Account Page"
-    Title: "Past Orders"
-    NO_PAGE: "No AccountPage was found. Please create one in the CMS!"
-  AccountPage.ss:
-    COMPLETED: "Completed Orders"
-    HISTORY: "Your Order History"
-    INCOMPLETE: "Incomplete Orders"
-    NOCOMPLETED: "No completed orders were found."
-    NOINCOMPLETE: "No incomplete orders were found."
-    ORDER: Order
-    READMORE: "Read more on Order #%s"
+    AddressBook: 'Address Book'
+    DESCRIPTION: 'Allows the user to view his account-details and past orders.'
+    DefaultTitle: Account
+    EditProfile: 'Edit Profile'
+    LogOut: 'Log Out'
+    Login: "You'll need to login before you can access the account page. If you are not registered, you won't be able to access it until you make your first order, otherwise please enter your details below."
+    LoginAgain: 'You have been logged out. If you would like to log in again, please do so below.'
+    MemberEmail: Email
+    MemberLastVisit: 'Last Visit'
+    MemberName: Name
+    MemberSince: 'Member Since'
+    NoPage: 'No AccountPage was found. Please create one in the CMS!'
+    NoPastOrders: 'No past orders found.'
+    NumberOfOrders: 'Number of orders'
+    PLURALNAME: 'Account Pages'
+    PastOrders: 'Past Orders'
+    SINGULARNAME: 'Account Page'
+    Title: 'My Account'
   AccountPage_AddressBook:
-    CreateNewTitle: "Create New Address"
-    NoAddress: "No addresses found."
-    Title: "Default Addresses"
+    CreateNewTitle: 'Create new address'
+    NoAddress: 'No addresses found.'
+    Title: 'Default addresses'
   AccountPage_EditProfile:
-    Title: "Edit Profile"
-  AccountPage_order.ss:
-    ADDRESS: Address
-    AMOUNT: Amount
-    BACKTOCHECKOUT: "Click here to go to the checkout page"
-    CITY: City
-    COUNTRY: Country
-    DATE: Date
-    DETAILS: Details
-    EMAILDETAILS: "A copy of this has been sent to your email address confirming the order details."
-    NAME: Name
-    PAYMENTMETHOD: Method
-    PAYMENTSTATUS: "Payment Status"
-  AddProductForm:
-    ADDTOCART: "Add to Cart"
-    Quantity: Quantity
+    Title: 'Edit Profile'
   Address:
-    ADDRESS: Address
-    ADDRESS2HINT: "premises, building, apartment, unit, floor"
-    ADDRESSHINT: "street / thoroughfare number, name, and type or P.O. Box"
-    ADDRESSLINE2: "Address Line 2 (optional)"
-    BillingAddress: "Billing Address"
-    CITY: City
-    CITYHINT: "or suburb, county, district"
-    COUNTRY: Country
-    PHONE: "Phone Number"
+    AddressHint: 'street / thoroughfare number, name, and type or P.O. Box'
+    AddressLine2Hint: 'premises, building, apartment, unit, floor'
+    BillingAddress: 'Billing Address'
+    CityHint: 'or suburb, county, district'
+    CreateNewAddress: 'Create new address'
+    ExistingBillingAddress: 'Existing Billing Address'
+    ExistingShippingAddress: 'Existing Shipping Address'
     PLURALNAME: Addresses
-    POSTALCODE: "Postal Code"
     SINGULARNAME: Address
-    STATE: State
-    STATEHINT: "or province, territory, island"
-    SaveDefaults: "Save Defaults"
-    SaveNew: "Save New Address"
-    ShippingAddress: "Shipping Address "
+    SaveDefaults: 'Save Defaults'
+    SaveNew: 'Save New Address'
+    ShippingAddress: 'Shipping Address'
+    StateHint: 'or province, territory, island'
     db_Address: Address
-    db_AddressLine2: "Address Line2"
+    db_AddressLine2: 'Address Line 2 (optional)'
     db_City: City
     db_Company: Company
     db_Country: Country
-    db_FirstName: "First Name"
-    db_Latitude: Latitude
-    db_Longitude: Longitude
-    db_Phone: Phone
-    db_PostalCode: "Postal Code"
+    db_FirstName: 'First Name'
+    db_Phone: 'Phone Number'
+    db_PostalCode: 'Postal Code'
     db_State: State
     db_Surname: Surname
     has_one_Member: Member
-  AddressBookCheckoutComponent:
-    CREATENEWADDRESS: "Create new address"
-    EXISTING_BILLING_ADDRESS: "Existing Billing Address"
-    EXISTING_SHIPPING_ADDRESS: "Existing Shipping Address"
-    EXISTING_ADDRESS: "Existing Address"
-  Cart.ss:
-    ADDONE: "Add one more of \"%s\" to your cart"
-    CheckoutClick: "Click here to go to the checkout"
-    CheckoutGoTo: "Go to checkout"
-    HEADLINE: "My Cart"
-    NOITEMS: "There are no items in your cart."
-    PRICE: Price
-    PRODUCT: Product
-    QUANTITY: Quantity
-    READMORE: "Click here to read more on \"%s\""
-    REMOVE: "Remove \"%s\" from your order"
-    REMOVEALL: "Remove all of \"%s\" from your cart"
-    REMOVEONE: "Remove one of \"%s\" from your cart"
-    SUBTOTAL: Sub-total
-    TABLESUMMARY: "Current contents of your cart."
-    TOTAL: Total
-    TOTALPRICE: "Total Price"
-    UNITPRICE: "Unit Price"
+  CartForm:
+    REMOVED_ITEMS: 'Removed {count} items.'
+    UPDATED_ITEMS: 'Updated {count} items.'
+    UpdateCart: 'Update Cart'
   CartPage:
-    DESCRIPTION: "Generic content page"
-    PLURALNAME: "Cart Pages"
-    SINGULARNAME: "Cart Page"
-    TITLE: "Shopping Cart"
-    has_one_CheckoutPage: "Checkout Page"
-    has_one_ContinuePage: "Continue Page"
-  CartPage.ss:
-    CARTEMPTY: "Your cart is empty."
-    CONTINUE: "Continue Shopping"
-    PROCEEDTOCHECKOUT: "Proceed to Checkout"
+    DESCRIPTION: 'A page where the user will be able to see and edit his shopping-cart contents.'
+    DefaultTitle: 'Shopping Cart'
+    PLURALNAME: 'Cart Pages'
+    SINGULARNAME: 'Cart Page'
+    has_one_CheckoutPage: 'Checkout Page'
+    has_one_ContinuePage: 'Continue Page'
   Checkout:
-    IDFIELDNOTFOUND: "Required field not found: %s"
-    MEMBEREXISTS: "A member already exists with the %s %s"
-    MEMBERSHIPSNOTALLOWED: "Creating new memberships is not allowed"
-    NOPAYMENTMETHOD: "Payment method does not exist"
-    PASSWORDREQUIRED: "A password is required"
+    IdFieldNotFound: 'Required field not found: {IdentifierField}'
+    MemberExists: 'A member already exists with the {Field} {Identifier}'
+    MembershipIsNotAllowed: 'Creating new memberships is not allowed'
+    NoPaymentMethod: 'Payment method does not exist'
+    PasswordRequired: 'A password is required'
+    TermsAndConditionsLink: 'I agree to the terms and conditions stated on the <a href="{TermsPageLink}" target="new" title="Read the shop terms and conditions for this site">{TermsPageTitle}</a> page'
   CheckoutComponentValidator:
-    INVALIDMESSAGE: "There are problems with the data you entered. See below:"
+    InvalidDataMessage: 'There are problems with the data you entered. See below:'
   CheckoutField:
-    ACCOUNTINFO: "Please choose a password, so you can login and check your order history in the future"
-    EMAIL: Email
-    FIRSTNAME: "First Name"
-    MEMBERINFO: "If you are already a member please"
-    MEMBERSHIPDETAILS: "Membership Details"
-    MUSTAGREETOTERMS: "You must agree to the terms and conditions"
-    NOTES: Message
-    PASSWORD: Password
-    SURNAME: Surname
-    TERMSANDCONDITIONS: "I agree to the terms and conditions stated on the <a href=\"%s\" target=\"new\" class=\"read_terms\" title=\"Read the shop terms and conditions for this site\">terms and conditions</a> page"
-    PAYMENT_TYPE: "Payment Type"
-  CheckoutFields:
-    PAYMENTTYPE: "Payment Type"
-  CheckoutForm:
-    PROCEED: "Proceed to payment"
+    AccountInfo: 'Please choose a password, so you can login and check your order history in the future'
+    MemberLoginInfo: 'If you are already a member please <a href="{LoginUrl">log in</a>'
+    MembershipDetails: 'Membership Details'
+    MustAgreeToTerms: 'You must agree to the terms and conditions'
+    Password: Password
+    PaymentType: 'Payment Type'
   CheckoutPage:
-    DESCRIPTION: "Generic content page"
-    NOPAGE: "No CheckoutPage on this site - please create one!"
-    PLURALNAME: "Checkout Pages"
-    PaymentErrorMessage: "Received error from payment gateway:"
-    SINGULARNAME: "Checkout Page"
-    TITLE: Checkout
-    db_PurchaseComplete: "Purchase Complete"
-    PURCHASE_COMPLETE_DESCRIPTION: "This message is included in reciept email, after the customer submits the checkout"
-    SUBMIT_PAYMENT: "Submit Payment"
-  CheckoutPage.ss:
-    CARTEMPTY: "Your cart is empty."
-    CHECKOUT: Checkout
-    ORDERSTATUS: "Order Status"
-    PROCESS: Process
-  ChequePayment:
-    MESSAGE: "Payment accepted via Cheque. Please note : products will not be shipped until payment has been received."
-    PLURALNAME: "Cheque Payments"
-    SINGULARNAME: "Cheque Payment"
+    DESCRIPTION: 'Page that handles the checkout-process.'
+    DefaultTitle: Checkout
+    PLURALNAME: 'Checkout Pages'
+    PaymentErrorMessage: 'Received error from payment gateway:'
+    ProceedToPayment: 'Proceed to payment'
+    PurchaseCompleteDescription: 'This message is included in reciept email, after the customer submits the checkout.'
+    SINGULARNAME: 'Checkout Page'
+    SubmitPayment: 'Submit Payment'
+    db_PurchaseComplete: 'Purchase Complete'
+  CheckoutStep:
+    Continue: Continue
+    Shipping: Shipping
+    Summary: Summary
+  CheckoutStep_Address:
+    BillTo: 'Bill To:'
+    EnterShippingAddress: 'Please enter your shipping address details.'
+    SeperateBilling: 'Bill to a different address from this'
+    ShipTo: 'Ship To:'
+    SupplyContactInformation: 'Supply your contact information'
+  CheckoutStep_Membership:
+    ContinueAsGuest: 'Continue as Guest'
+    CreateAccount: 'Create an Account'
+    CreateNewAccount: 'Create New Account'
   CreateAddressForm:
-    SAVED: "Your address has been saved"
-  DPSPayment:
-    PLURALNAME: "D P S Payments"
-    SINGULARNAME: "D P S Payment"
-  EwayXMLPayment:
-    PLURALNAME: "Eway X M L Payments"
-    SINGULARNAME: "Eway X M L Payment"
+    AddressSaved: 'Your address has been saved'
+  CustomerReport:
+    Description: 'Customers report'
+    Title: Customers
   FlatTaxModifier:
     PLURALNAME: Taxes
     SINGULARNAME: Tax
   FreeShippingModifier:
-    FREE: FREE
-    PLURALNAME: Modifiers
+    Free: FREE
+    PLURALNAME: 'Free Shipping Modifiers'
     SINGULARNAME: Shipping
-  General:
-    DATEFORMATLONG: "%m/%d/%G %I:%M%p"
-    DATEFORMATNICE: "%m/%d/%G"
-    DATEFORMATSHORT: "%m/%d/%G"
-    DATETIMEFORMATNICE: "%m/%d/%G %I:%M%p"
-    DATETIMEFORMATNICE24: "d/m/Y H:i"
   GlobalTaxModifier:
-    INCLUDED: " (included in the above price)"
+    Included: ' (included in the above price)'
     PLURALNAME: Taxes
     SINGULARNAME: Tax
     db_Country: Country
-  Member:
-    BUTTONCHANGEPASSWORD: "Change Password"
-    CONFIRMNEWPASSWORD: "Confirm New Password"
-    NEWPASSWORD: "New Password"
-    YOUROLDPASSWORD: "Your old password"
   MemberForm:
-    DETAILSSAVED: "Your details have been saved"
-    LOGGEDIN: "You are currently logged in as "
-    SAVE: "Save Changes"
-    SAVEANDPROCEED: "Save and proceed to checkout"
-  ORDER:
-    INVOICE: Invoice
+    DetailsSaved: 'Your details have been saved'
+    Save: 'Save Changes'
+    SaveAndProceed: 'Save and proceed to checkout'
+  OnsitePaymentCheckoutComponent:
+    InvalidCreditCard: 'Credit card is invalid'
   Order:
-    CANCELSUBJECT: "Order #%d cancelled by member"
-    INCOMPLETE: "Order Incomplete"
+    BillTo: 'Bill To'
+    Date: Date
+    DateFrom: 'Date from'
+    DateTo: 'Date to'
+    GrandTotal: 'Grand Total'
+    Invoice: Invoice
+    OrderHeadline: 'Order #{OrderNo} {OrderDate}'
+    Outstanding: Outstanding
+    OutstandingWithAmount: 'Outstanding: {Amount}'
     PLURALNAME: Orders
-    PRINT: Print
+    Print: Print
+    Quantity: Quantity
     SINGULARNAME: Order
-    SUCCESSFULL: "Order Successful"
-    DATE_FROM: "Date from"
-    DATE_TO: "Date to"
-    db_AnalyticsSubmitted: "Analytics Submitted"
+    STATUS_ADMINCANCELLED: 'Cancelled by admin'
+    STATUS_CART: Cart
+    STATUS_COMPLETE: Complete
+    STATUS_MEMBERCANCELLED: 'Cancelled by member'
+    STATUS_PAID: Paid
+    STATUS_PROCESSING: Processing
+    STATUS_SENT: Sent
+    STATUS_UNPAID: Unpaid
+    ShipTo: 'Ship To'
+    SubTotal: Sub-total
+    Total: Total
+    TotalOutstanding: 'Total outstanding'
+    TotalPrice: 'Total Price'
+    TotalPriceWithCurrency: 'Total Price ({Currency})'
+    UnitPrice: 'Unit Price'
     db_Dispatched: Dispatched
     db_Email: Email
-    db_FirstName: "First Name"
-    db_IPAddress: IPAddress
-    db_Notes: Notes
+    db_FirstName: 'First Name'
+    db_IPAddress: 'IP Address'
+    db_Notes: Message
     db_Paid: Paid
     db_Placed: Placed
     db_Printed: Printed
-    db_ReceiptSent: "Receipt Sent"
+    db_ReceiptSent: 'Receipt Sent'
     db_Reference: Reference
-    db_SeparateBillingAddress: "Separate Billing Address"
-    db_ShippingTotal: "Shipping Total"
+    db_SeparateBillingAddress: 'Separate Billing Address'
     db_Status: Status
     db_Surname: Surname
     db_Total: Total
     has_many_Items: Items
     has_many_Modifiers: Modifiers
-    has_many_OrderStatusLogs: "Order Status Logs"
+    has_many_OrderStatusLogs: 'Order Status Logs'
     has_many_Payments: Payments
-    has_one_BillingAddress: "Billing Address"
+    has_one_BillingAddress: 'Billing Address'
     has_one_Member: Member
-    has_one_ShippingAddress: "Shipping Address"
-    has_one_ShippingMethod: "Shipping Method"
-  Order.ss:
-    ORDERNOTES: Notes
-    TOTALOUTSTANDING: "Total outstanding"
+    has_one_ShippingAddress: 'Shipping Address'
   OrderActionsForm:
-    CANCELORDER: "Cancel this order"
-    MAKEPAYMENT: "Make Payment"
-    OUTSTANDING: "Outstanding: %s"
-    PAYMENTMETHOD: "Payment Method"
-    PAYORDER: "Pay outstanding balance"
-    MANUAL_NOT_ALLOWED: "Manual payment not allowed"
-  OrderAdmin_Addresses.ss:
-    ADDRESS: Address
-    BILLTO: "Bill To"
-    SHIPTO: "Ship To"
-  OrderAdmin_Content.ss:
-    ITEMS: Items
-    PRODUCT: Product
-    QUANTITY: Quantity
-    TOTALPRICE: "Total Price"
-    UNITPRICE: "Unit Price"
-  OrderAdmin_Content_ItemLine.ss:
-    READMORE: "View \"%s\""
-  OrderAdmin_Content_SubTotals.ss:
-    SUBTOTAL: Sub-total
-    TOTAL: Total
-    TOTALOUTSTANDING: Outstanding
-  OrderAdmin_Customer.ss:
-    CUSTOMER: Customer
-  OrderAdmin_Notes.ss:
-    NOTES: Notes
-  OrderAdmin_Printable.ss:
-    ORDER: Order
+    CancelOrder: 'Cancel this order'
+    MakePayment: 'Make Payment'
+    ManualNotAllowed: 'Manual payment not allowed'
+    PayOrder: 'Pay outstanding balance'
+    PaymentMethod: 'Payment Method'
+  OrderAdmin:
+    ReceiptTitle: '{SiteTitle} Order {OrderNo}'
   OrderAttribute:
     PLURALNAME: Attributes
     SINGULARNAME: Attribute
-    db_CalculatedTotal: "Calculated Total"
+    db_CalculatedTotal: 'Calculated Total'
     has_one_Order: Order
   OrderForm:
-    COULDNOTPROCESSPAYMENT: "Payment could not be processed."
-    LogIn: "log in"
-    ORDERCANCELLED: "Order sucessfully cancelled"
-  OrderHistory:
-    OrderDate: Date
-    OrderItems: Items
-    OrderReference: Reference
-    OrderStatus: Status
-    OrderTotal: Total
-    ViewOrder: view
-  OrderInformation.ss:
-    ADDRESS: Address
-    AMOUNT: Amount
-    BUYERSADDRESS: "Buyer's Address"
-    CITY: City
-    COUNTRY: Country
-    CUSTOMERDETAILS: "Customer Details"
-    DATE: Date
-    DETAILS: Details
-    EMAIL: Email
-    MOBILE: Mobile
-    NAME: Name
-    ORDERSUMMARY: "Order Summary"
-    PAYMENTID: "Payment ID"
-    PAYMENTINFORMATION: "Payment Information"
-    PAYMENTMETHOD: Method
-    PAYMENTSTATUS: "Payment Status"
-    PHONE: Phone
-    PRICE: Price
-    PRODUCT: Product
-    QUANTITY: Quantity
-    READMORE: "Click here to read more on \"%s\""
-    SHIPPINGDETAILS: "Shipping Details"
-    SUBTOTAL: Sub-total
-    TOTAL: Total
-    TOTALOUTSTANDING: "Total outstanding"
-    TOTALPRICE: "Total Price"
-  OrderInformation_Editable.ss:
-    ADDONE: "Add one more of \"%s\" to your cart"
-    NOITEMS: "There are <strong>no</strong> items in your cart."
-    ORDERINFORMATION: "Order Information"
-    PRICE: Price
-    PRODUCT: Product
-    QUANTITY: Quantity
-    READMORE: "Click here to read more on \"%s\""
-    REMOVE: "Remove \"%s\" from your order"
-    REMOVEALL: "Remove all of \"%s\" from your cart"
-    REMOVEONE: "Remove one of \"%s\" from your cart"
-    SUBTOTAL: Sub-total
-    TABLESUMMARY: "The contents of your cart are displayed in this form and summary of all fees associated with an order and a rundown of payments options."
-    TOTAL: Total
-    TOTALPRICE: "Total Price"
-  OrderInformation_NoPricing.ss:
-    ADDRESS: Address
-    BUYERSADDRESS: "Buyer's Address"
-    CITY: City
-    COUNTRY: Country
-    CUSTOMERDETAILS: "Customer Details"
-    EMAIL: Email
-    MOBILE: Mobile
-    NAME: Name
-    ORDERINFO: "Information for Order #"
-    PHONE: Phone
-    TABLESUMMARY: "The contents of your cart are displayed in this form and summary of all fees associated with an order and a rundown of payments options."
-  OrderInformation_PackingSlip.ss:
-    DESCRIPTION: Description
-    ITEM: Item
-    ORDERDATE: "Order Date"
-    ORDERNUMBER: "Order Number"
-    PAGETITLE: "Shop Print Orders"
-    QUANTITY: Quantity
-    TABLESUMMARY: "The contents of your cart are displayed in this form and summary of all fees associated with an order and a rundown of payments options."
-  OrderInformation_Print.ss:
-    PAGETITLE: "Print Orders"
+    CouldNotProcessPayment: 'Payment could not be processed.'
+    OrderCancelled: 'Order sucessfully cancelled'
   OrderItem:
     PLURALNAME: Items
     SINGULARNAME: Item
     db_Quantity: Quantity
-    db_UnitPrice: "Unit Price"
+    db_UnitPrice: 'Unit Price'
   OrderModifier:
     PLURALNAME: Modifiers
     SINGULARNAME: Modifier
     db_Amount: Amount
     db_Sort: Sort
     db_Type: Type
-  OrderNotifier:
-    ADMINNOTIFICATIONSUBJECT: "Order #%d Notification"
-    CONFIRMATIONSUBJECT: "Order #%d Confirmation"
-    RECEIPTSUBJECT: "Order #%d Receipt"
   OrderProcessor:
-    NULL: "A new order has not yet been started."
-    NOITEMS: "Order has no items."
-    NOTCART: "Order is not a cart."
-  OrderReport:
-    CHANGESTATUS: "Change Order Status"
-    NOTEEMAIL: Note/Email
-    SENDNOTETO: "Send this note to %s (%s)"
+    NoItems: 'Order has no items.'
+    NoOrder: 'Order does not exist.'
+    NoOrderStarted: 'A new order has not yet been started.'
+    NotCart: 'Order is not a cart.'
   OrderStatusLog:
-    PLURALNAME: "Order Status Log Entries"
-    SINGULARNAME: "Order Log Entry"
-    db_DispatchTicket: "Dispatch Ticket"
-    db_DispatchedBy: "Dispatched By"
-    db_DispatchedOn: "Dispatched On"
+    PLURALNAME: 'Order Status Log Entries'
+    SINGULARNAME: 'Order Log Entry'
+    db_DispatchTicket: 'Dispatch Ticket'
+    db_DispatchedBy: 'Dispatched By'
+    db_DispatchedOn: 'Dispatched On'
     db_Note: Note
-    db_PaymentCode: "Payment Code"
-    db_PaymentOK: "Payment OK"
-    db_SentToCustomer: "Sent To Customer"
+    db_PaymentCode: 'Payment Code'
+    db_PaymentOK: 'Payment OK'
+    db_SentToCustomer: 'Sent To Customer'
     db_Title: Title
     has_one_Author: Author
     has_one_Order: Order
-  Order_Address.ss:
-    BILLTO: "Bill To"
-    SHIPTO: "Ship To"
-  Order_AdminNotificationEmail.ss:
-    TITLE: "Shop Receipt"
-  Order_ConfirmationEmail.ss:
-    TITLE: "Order Confirmation"
-  Order_Content.ss:
-    NOITEMS: "There are <strong>no</strong> items in your order."
-    PRICE: Price
-    PRODUCT: Product
-    QUANTITY: Quantity
-    READMORE: "Click here to read more on \"%s\""
-    SUBTOTAL: Sub-total
-    TOTAL: Total
-    TOTALOUTSTANDING: "Total outstanding"
-    TOTALPRICE: "Total Price"
-    UNITPRICE: "Unit Price"
-  Order_Content_ItemLine.ss:
-    READMORE: "View \"%s\""
-  Order_Content_SubTotals.ss:
-    SUBTOTAL: Sub-total
-    TOTAL: Total
-  Order_ItemLine.ss:
-    READMORE: "View \"%s\""
-  Order_Member.ss:
-    ADDRESS: Address
-    CITY: City
-    COUNTRY: Country
-    EMAIL: Email
-    MOBILE: Mobile
-    NAME: Name
-    PHONE: Phone
-  Order_Payments.ss:
-    AMOUNT: Amount
-    DATE: Date
-    PAYMENTMETHOD: Method
-    PAYMENTNOTE: Note
-    PAYMENTSTATUS: "Payment Status"
-  Order_ReceiptEmail.ss:
-    HEADLINE: "Shop Order Receipt"
-    TITLE: "Shop Receipt"
-  Order_StatusEmail.ss:
-    HEADLINE: "Shop Status Change"
-    STATUSCHANGE: "Status changed to \"%s\" for Order #"
-    TITLE: "Shop Status Change"
-  OrdersAdmin:
-    MENUTITLE: Orders
-  PayPalPayment:
-    PLURALNAME: "Pay Pal Payments"
-    SINGULARNAME: "Pay Pal Payment"
   Payment:
-    AMOUNT: Amount
-    PAYMENTTYPE: "Payment Type"
-    PLURALNAME: Payments
-    SINGULARNAME: Payment
-    SUBTOTAL: Subtotal
-  PaymentInformation.ss:
-    AMOUNT: Amount
-    DATE: Date
-    DETAILS: Details
-    PAYMENTID: "Payment ID"
-    PAYMENTINFORMATION: "Payment Information"
-    PAYMENTMETHOD: Method
-    PAYMENTSTATUS: "Payment Status"
-    TABLESUMMARY: "The contents of your cart are displayed in this form and summary of all fees associated with an order and a rundown of payments options."
+    Note: Note
+    PaymentsHeadline: Payment(s)
+  PaymentCheckoutComponent:
+    NoPaymentMethod: 'Payment method not provided'
+    UnsupportedGateway: 'Gateway not supported'
   PaymentProcessor:
-    INVALID_GATEWAY: "`{gateway}` isn't a valid payment gateway."
-    CANTPAY: "Order can't be paid for."
-  PaystationHostedPayment:
-    PLURALNAME: "Paystation Hosted Payments"
-    SINGULARNAME: "Paystation Hosted Payment"
-  PaystationPayment:
-    PLURALNAME: "Paystation Payments"
-    SINGULARNAME: "Paystation Payment"
+    CantPay: "Order can't be paid for."
+    InvalidGateway: "`{gateway}` isn't a valid payment gateway."
   PickupShippingModifier:
     PLURALNAME: Modifiers
-    SINGULARNAME: "Pick Up Shipping"
+    SINGULARNAME: 'Pick Up Shipping'
+  PriceTag:
+    SAVE: Save
   Product:
-    ADDITIONALCATEGORIES: "Additional Categories"
-    ALLOWPURCHASE: "Allow product to be purchased"
-    CATEGORY: Category
-    CATEGORYDESCRIPTION: "This is the parent page or default category."
-    CODE: "Product Code/SKU"
-    CODE_SHORT: "SKU"
-    COSTPRICE: "Cost Price"
-    COSTPRICEDESC: "Wholesale price before markup."
-    DEPTH: "Depth (%s)"
-    DESCRIPTION: "Generic content page"
-    FEATURED: "Featured Product"
-    HEIGHT: "Height (%s)"
-    IMAGE: "Product Image"
-    MODEL: Model
-    PAGETITLE: "Product Title"
+    AddToCart: 'Add to Cart'
+    AddToCartTitle: 'Add &quot;{Title}&quot; to your cart'
+    AdditionalCategories: 'Additional Categories'
+    AllowPurchase: 'Allow product to be purchased'
+    Category: Category
+    CategoryDescription: 'This is the parent page or default category.'
+    Code: 'Product Code'
+    CostPriceDescription: 'Wholesale price before markup.'
+    DESCRIPTION: 'Generic content page'
+    Featured: 'Featured Product'
+    Image: 'Product Image'
+    ImageAltText: '{Title} image'
+    InternalItemID: 'Product Code/SKU'
+    Model: Model
+    NoImage: 'no image'
     PLURALNAME: Products
-    PRICE: Price
-    PRICEDESC: "Base price to sell this product at."
+    PageTitle: 'Product Title'
+    Price: Price
+    PriceDesc: 'Base price to sell this product at.'
+    ProductCodeShort: SKU
     SINGULARNAME: Product
-    WEIGHT: "Weight (%s)"
-    WIDTH: "Width (%s)"
-    NO_IMAGE: "no image"
-    db_AllowPurchase: "Allow Purchase"
-    db_BasePrice: "Base Price"
-    db_CostPrice: "Cost Price"
+    Size: Size
+    View: 'View Product'
+    db_AllowPurchase: 'Allow Purchase'
+    db_BasePrice: Price
+    db_CostPrice: 'Cost Price'
     db_Depth: Depth
     db_Featured: Featured
     db_Height: Height
-    db_InternalItemID: "Internal Item ID"
+    db_InternalItemID: 'Internal Item ID'
     db_Model: Model
     db_Popularity: Popularity
     db_Weight: Weight
     db_Width: Width
     has_many_Variations: Variations
     has_one_Image: Image
-    many_many_ProductCategories: "Product Categories"
-    many_many_VariationAttributeTypes: "Variation Attribute Types"
-  Product.ss:
-    ADD: "Add \"%s\" to your cart"
-    ADDLINK: "Add this item to cart"
-    ADDONE: "Add one more of \"%s\" to your cart"
-    AUTHOR: Author
-    CODE: "Product Code"
-    FEATURED: "This is a featured product."
-    GOTOCHECKOUT: "Go to the checkout now"
-    GOTOCHECKOUTLINK: "» Go to the checkout"
-    IMAGE: "%s image"
-    ItemID: "Item #"
-    MODEL: Model
-    NOIMAGE: "Sorry, no product image for \"%s\""
-    QUANTITYCART: "Quantity in cart"
-    REMOVE: "Remove \"%s\" from your cart"
-    REMOVEALL: "Remove one of \"%s\" from your cart"
-    REMOVELINK: "» Remove from cart"
-    SIZE: Size
+    many_many_ProductCategories: 'Product Categories'
+    many_many_VariationAttributeTypes: 'Variation Attribute Types'
   ProductAttributeType:
     PLURALNAME: Attributes
     SINGULARNAME: Attribute
-    SAVE_FIRST_MESSAGE: "Save first, then you can add values."
+    SaveFirstInfo: 'Save first, then you can add values.'
     belongs_many_many_Product: Product
     db_Label: Label
     db_Name: Name
@@ -523,248 +291,195 @@ en:
   ProductAttributeValue:
     PLURALNAME: Values
     SINGULARNAME: Value
-    belongs_many_many_ProductVariation: "Product Variation"
+    belongs_many_many_ProductVariation: 'Product Variation'
     db_Sort: Sort
     db_Value: Value
     has_one_Type: Type
-  ProductCatalogAdmin:
-    MENUTITLE: Catalog
   ProductCategory:
-    DESCRIPTION: "Generic content page"
+    DESCRIPTION: 'Generic content page'
     PLURALNAME: Categories
     SINGULARNAME: Category
     belongs_many_many_Products: Products
-  ProductCategory.ss:
-    FEATURED: "Featured Products"
-    OTHER: "Other Products"
-  ProductCategoryItem.ss:
-    ADD: "Add \"%s\" to your cart"
-    ADDLINK: "Add this item to cart"
-    ADDONE: "Add one more of \"%s\" to your cart"
-    AUTHOR: Author
-    GOTOCHECKOUT: "Go to the checkout now"
-    GOTOCHECKOUTLINK: "» Go to the checkout"
-    IMAGE: "%s image"
-    NOIMAGE: "Sorry, no product image for \"%s\""
-    QUANTITYCART: "Quantity in cart"
-    READMORE: "Click here to read more on \"%s\""
-    READMORECONTENT: "Click to read more »"
-    REMOVE: "Remove \"%s\" from your cart"
-    REMOVEALL: "Remove one of \"%s\" from your cart"
-    REMOVELINK: "» Remove from cart"
   ProductGroup:
     NEXT: next
     PAGE: page
     PREVIOUS: previous
-    VIEW_PREVIOUS: "View the previous page"
-    VIEW_NEXT: "View the next page"
-    VIEW_PAGE: "View page number {pageNum}"
-  ProductGroupItem.ss:
-    ADD: "Add \"%s\" to your cart"
-    ADDLINK: "Add to Cart"
-    IMAGE: "%s image"
-    MODEL: Model
-    READMORE: "Click here to read more on \"%s\""
-    VIEW: "View Product"
-  ProductMenu.ss:
-    GOTOPAGE: "Go to the %s page"
+    VIEW_NEXT: 'View the next page'
+    VIEW_PAGE: 'View page number {pageNum}'
+    VIEW_PREVIOUS: 'View the previous page'
+  ProductMenu:
+    GotoPageTitle: 'Go to the {Title} page'
+  ProductReport:
+    Description: "Understand which products are performing, and which aren't."
+    Title: Products
   ProductVariation:
+    MustSaveFirstMessage: 'You can choose variation attributes after saving for the first time, if they exist.'
+    NoAttributeValuesMessage: '{attribute} has no values to choose from. You can create them in the "Products" &#62; "Product Attribute Type" section of the CMS.'
     PLURALNAME: Variations
     SINGULARNAME: Variation
-    db_InternalItemID: "Internal Item ID"
+    db_InternalItemID: 'Internal Item ID'
     db_Price: Price
     db_Version: Version
     has_one_Image: Image
     has_one_Product: Product
-    many_many_AttributeValues: "Attribute Values"
-    NO_ATTRIBUTE_VALUES_MESSAGE: "{attribute} has no values to choose from. You can create them in the \"Products\" &#62; \"Product Attribute Type\" section of the CMS."
-    SAVE_FIRST_MESSAGE: "You can choose variation attributes after saving for the first time, if they exist."
-  ProductVariationsExtension:
-    ATTRIBUTES: "Attributes"
-    ATTRIBUTES_DESCRIPTION: "These are fields to indicate the way(s) each variation varies. Once selected, they can be edited on each variation."
-    VARIATIONS: "Variations"
-    VARIATIONS_INSTRUCTIONS: "Price - Because you have one or more variations, the price can be set in the \"Variations\" tab."
+    many_many_AttributeValues: 'Attribute Values'
   ProductVariation_OrderItem:
     PLURALNAME: Items
     SINGULARNAME: Item
-    db_ProductVariationVersion: "Product Variation Version"
-    has_one_ProductVariation: "Product Variation"
+    db_ProductVariationVersion: 'Product Variation Version'
+    has_one_ProductVariation: 'Product Variation'
+  ProductVariationsExtension:
+    Attributes: Attributes
+    AttributesDescription: 'These are fields to indicate the way(s) each variation varies. Once selected, they can be edited on each variation.'
+    Variations: Variations
+    VariationsInfo: 'Price - Because you have one or more variations, the price can be set in the "Variations" tab.'
   Product_OrderItem:
     PLURALNAME: Items
     SINGULARNAME: Item
-    db_ProductVersion: "Product Version"
+    db_ProductVersion: 'Product Version'
     has_one_Product: Product
   RegionRestriction:
-    PLURALNAME: "Region Restrictions"
-    SINGULARNAME: "Region Restriction"
+    PLURALNAME: 'Region Restrictions'
+    SINGULARNAME: 'Region Restriction'
     db_City: City
     db_Country: Country
-    db_PostalCode: "Postal Code"
+    db_PostalCode: 'Postal Code'
     db_State: State
   SetLocationForm:
-    CHOOSECOUNTRY: "Choose country..."
-    COUNTRY: Country
+    ChooseCountry: 'Choose country...'
+    Country: Country
   ShippingModifier:
     PLURALNAME: Modifiers
     SINGULARNAME: Shipping
   Shop:
-    DEVTOOLSTITLE: "Shop Development Tools"
+    Change: Change
+    Customer: Customer
+    Date: Date
+    DateFormatNice: '%m/%d/%G'
+    DateTimeFormatNice: '%m/%d/%G %I:%M%p'
+    DateTimeFormatNice24: 'd/m/Y H:i'
+    DevToolsTitle: 'Shop Development Tools'
+    Edit: Edit
+    Quantity: Quantity
+    ReadMoreTitle: 'Click here to read more on &quot;{Title}&quot;'
+    Remove: Remove
+    View: view
   ShopConfig:
-    CUSTOMERGROUP: "Group to add new customers to"
-    DEFAULTIMAGE: "Default Product Image"
-    TERMSPAGE: "Terms and Conditions Page"
-    ALLOWED_COUNTRIES: "Allowed Ordering and Shipping Countries"
-    ALLOWED_COUNTRIES_TAB_TITLE: "Allowed Countries"
+    AllowedCountries: 'Allowed Ordering and Shipping Countries'
+    AllowedCountriesTabTitle: 'Allowed Countries'
+    CustomerGroup: 'Group to add new customers to'
+    DefaultImage: 'Default Product Image'
+    TermsPage: 'Terms and Conditions Page'
   ShopCurrency:
-    FREE: "<span class=\"free\">FREE</span>"
+    Free: '<span class="free">FREE</span>'
   ShopDashboard:
-    RECENTORDERS: "Recent Orders"
-    RECENTORDERSDESCRIPTION: "Shows recent orders"
-    RecentAccounts: "Recent Accounts"
-    RecentAccountsDescription: "Shows recent account signups"
-    RecentOrdersChart: "Order History Chart"
-    RecentOrdersChartDescription: "Shows recent orders on a graph"
-    NUMBER_OF_ACCOUNTS: "Number of accounts to show"
-    NUMBER_OF_DAYS: "Number of days to show"
-    NUMBER_OF_ORDERS: "Number of orders to show"
-    # These should probably be moved into a more generic category, since they can be used in a lot of places
-    EDIT: "Edit"
-    CUSTOMER: "Customer"
-    DATE: "Date"
-  ShopDatabaseAdmin.ss:
-    BUILDTASKS: "Build Tasks"
-    CARTCLEANUP: "Cleanup old carts"
-    CARTCLEANUPDESC: "Remove abandoned carts."
-    CARTTASKS: "Cart tasks"
-    DEBUGCART: "Debug the shopping cart"
-    RECALCULATEORDERS: "Recalculate All Orders"
-    RECALCULATEORDERSDESC: "Recalculate all order values. Warning: this will overwrite any historical values."
-    RUNALLTESTS: "Run all shop unit tests"
-    UNITTESTS: "Unit Tests"
-  ShopDevelopmentAdmin.ss:
-    BUILDTASKS: "Build Tasks"
-    CARTCLEANUP: "Cleanup old carts"
-    CARTCLEANUPDESC: "Remove abandoned carts."
-    CARTTASKS: "Cart tasks"
-    CLEARCART: "Clear the current shopping cart"
-    DEBUGCART: "Debug the shopping cart"
-    DELETEORDERS: "Delete All Orders"
-    DELETEORDERSDESC: "Remove all orders, modifiers, and payments from the database."
-    DELETEPRODUCTS: "Delete All Products"
-    DELETEPRODUCTSDESC: "Remove all products from the database."
-    POPULATECART: "Populate cart with some available products"
-    POPULATESHOP: "Populate shop"
-    POPULATESHOPDESC: "Populate the shop with dummy products, categories, and other necessary pages."
-    RECALCULATEORDERS: "Recalculate All Orders"
-    RECALCULATEORDERSDESC: "Recalculate all order values. Warning: this will overwrite any historical values."
-    RUNALLTESTS: "Run all shop unit tests"
-    UNITTESTS: "Unit Tests"
-  ShopQuantityField.ss:
-    ADDONE: "Add one more of \"%s\" to your cart"
-    REMOVEONE: "Remove one of \"%s\" from your cart"
+    NumberOfAccounts: 'Number of accounts to show'
+    NumberOfDays: 'Number of days to show'
+    NumberOfOrders: 'Number of orders to show'
+    RecentAccounts: 'Recent Accounts'
+    RecentAccountsDescription: 'Shows recent account signups'
+    RecentOrders: 'Recent Orders'
+    RecentOrdersChart: 'Order History Chart'
+    RecentOrdersChartDescription: 'Shows recent orders on a graph'
+    RecentOrdersDescription: 'Shows recent orders'
+  ShopDevelopmentAdmin:
+    BuildTasks: 'Build Tasks'
+    CartCleanup: 'Cleanup old carts'
+    CartCleanupDesc: 'Remove abandoned carts.'
+    CartTasks: 'Cart tasks'
+    ClearCart: 'Clear the current shopping cart'
+    DebugCart: 'Debug the shopping cart'
+    DeleteOrders: 'Delete all orders'
+    DeleteOrdersDesc: 'Remove all orders, modifiers, and payments from the database.'
+    DeleteProducts: 'Delete all products'
+    DeleteProductsDesc: 'Remove all products from the database.'
+    PopulateCart: 'Populate cart with some available products'
+    PopulateShop: 'Populate shop'
+    PopulateShopDesc: 'Populate the shop with dummy products, categories, and other necessary pages.'
+    RecalculateOrders: 'Recalculate all orders'
+    RecalculateOrdersDesc: 'Recalculate all order values. Warning: this will overwrite any historical values.'
+    RunAllTests: 'Run all shop unit tests'
+    UnitTests: 'Unit Tests'
+  ShopEmail:
+    AdminNotificationSubject: 'Order #{OrderNo} notification'
+    AdminNotificationTitle: 'Shop Receipt'
+    CancelSubject: 'Order #{OrderNo} cancelled by member'
+    ConfirmationSubject: 'Order #{OrderNo} confirmation'
+    ConfirmationTitle: 'Order Confirmation'
+    ReceiptSubject: 'Order #{OrderNo} receipt'
+    ReceiptTitle: 'Shop Receipt'
+    StatusChangeTitle: 'Shop Status Change'
+    StatusChanged: 'Status for order #{OrderNo} changed to "{OrderStatus}"'
+  ShopPeriodReport:
+    Description: 'Shop Period Report'
+    Title: 'Shop Period Report'
+  ShopQuantityField:
+    AddOne: 'Add one more of &quot;{ItemTitle}&quot; to your cart'
+    RemoveOne: 'Remove one of &quot;{ItemTitle}&quot; from your cart'
+  ShopSalesReport:
+    Description: 'Monitor shop sales performance for a particular period. Group results by year, month, or day.'
+    Title: 'Shop Sales'
   ShopSideReport:
-    ALLPRODUCTS: "All Products"
-    FEATUREDPRODUCTS: "Featured Products"
-    HEAVY: "Heavy Products"
-    NOIMAGE: "Products with no image"
-    ShopGROUP: Shop
+    AllProducts: 'All Products'
+    FeaturedProducts: 'Featured Products'
+    Heavy: 'Heavy Products'
+    NoImage: 'Products with no image'
+    ShopGroup: Shop
   ShoppingCart:
-    CANNOTPURCHASE: "This %s cannot be purchased."
-    CLEARED: "Cart was successfully cleared."
-    CSRF: "Invalid security token, possible CSRF attack."
-    ITEMADD: "Item has been added successfully."
-    ITEMNOTFOUND: "Item not found."
-    ITEMREMOVED: "Item has been successfully removed."
-    NOCARTFOUND: "No cart found."
-    NOCARTINITIALISED: "no cart initialised"
-    NOORDER: "No current order."
-    PRODUCTNOTFOUND: "Product not found."
-    QUANTITYSET: "Quantity has been set."
-    # Pretty generic translation, could be moved to a more generic category
-    CHANGE: "Change"
-    ITEMS_IN_CART_PLURAL: "There are <a href=\"{link}\">{quantity} items</a> in your cart."
-    ITEMS_IN_CART_SINGULAR: "There is <a href=\"{link}\">1 item</a> in your cart."
-    CHECKOUT: "Checkout"
-  SideCart.ss:
-    HEADLINE: "My Cart"
-    NOITEMS: "There are no items in your cart"
-    READMORE: "View \"%s\""
-    REMOVEALL: "remove from cart"
+    CannotPurchase: 'This {Title} cannot be purchased.'
+    Checkout: Checkout
+    Cleared: 'Cart was successfully cleared.'
+    ContinueShopping: 'Continue Shopping'
+    Headline: 'Shopping cart'
+    InvalidSecurityToken: 'Invalid security token, possible CSRF attack.'
+    ItemAdded: 'Item has been added successfully.'
+    ItemNotFound: 'Item not found.'
+    ItemRemoved: 'Item has been successfully removed.'
+    ItemsInCartPlural: 'There are <a href="{link}">{quantity} items</a> in your cart.'
+    ItemsInCartSingular: 'There is <a href="{link}">1 item</a> in your cart.'
+    NoCartFound: 'No cart found.'
+    NoCartInitialised: 'no cart initialised'
+    NoItems: 'There are no items in your cart.'
+    NoOrder: 'No current order.'
+    ProceedToCheckout: 'Proceed to Checkout'
+    ProductNotFound: 'Product not found.'
+    QuantitySet: 'Quantity has been set.'
+    RemoveAllTitle: 'Remove all of &quot;{Title}&quot; from your cart'
+    RemoveTitle: 'Remove &quot;{Title}&quot; from your cart.'
+    TableSummary: 'Current contents of your cart.'
   SimpleShippingModifier:
-    PLURALNAME: Modifiers
-    SHIPTO: "Ship to %s"
+    PLURALNAME: 'Simple Shipping Modifiers'
     SINGULARNAME: Shipping
+    ShipToCountry: 'Ship to {Country}'
     db_Country: Country
-  SteppedCheckoutPage.ss:
-    NOITEMS: "There are no items in your cart."
   SubTotalModifier:
-    PLURALNAME: "Sub Totals"
-    SINGULARNAME: "Sub Total"
+    PLURALNAME: 'Sub Totals'
+    SINGULARNAME: 'Sub Total'
   TaxModifier:
-    ATRATE: "@ %s"
+    AtRate: '@ {Rate}%'
     PLURALNAME: Taxes
     SINGULARNAME: Tax
     db_Rate: Rate
-  VariationsTable.ss:
-    ADD: "Add \"%s\" to your cart"
-    ADDLINK: "Add this item to cart"
-    QUANTITYCART: "Quantity in cart"
+  TaxReport:
+    Description: 'Report tax charged on orders. Only includes orders that have been paid.'
+    Title: Tax
+  Variation:
+    SINGULARNAME: Variation
+  VariationForm:
+    ChooseAttribute: 'Choose {attribute} …'
+    ProductNotAvailable: 'This product is not available with the selected options.'
+    VariationNotAvailable: 'That variation is not available, sorry.'
   WeightShippingModifier:
-    PLURALNAME: Modifiers
+    PLURALNAME: 'Weight Shipping Modifiers'
     SINGULARNAME: Shipping
-    TABLETITLE: "Shipping (%f kg)"
-  WorldpayPayment:
-    PLURALNAME: "Worldpay Payments"
-    SINGULARNAME: "Worldpay Payment"
+    TableTitle: 'Shipping ({Kilograms} kg)'
   Zone:
     PLURALNAME: Zones
     SINGULARNAME: Zone
     db_Description: Description
     db_Name: Name
     has_many_Regions: Regions
-  ZoneAdmin:
-    MENUTITLE: Zones
   ZoneRegion:
-    PLURALNAME: "Zone Regions"
-    SINGULARNAME: "Zone Region"
+    PLURALNAME: 'Zone Regions'
+    SINGULARNAME: 'Zone Region'
     has_one_Zone: Zone
-  shop:
-    Checkout: "Payment Type"
-    STATUS: Status
-  CartEditField:
-    REMOVE: "Remove"
-    VARIATION: "Variation"
-  CartForm:
-    UPDATE_CART: "Update Cart"
-    REMOVED_ITEMS: "Removed {count} items."
-    UPDATED_ITEMS: "Updated {count} items."
-  OnsitePaymentCheckoutComponent:
-    CREDIT_CARD_INVALID: "Credit card is invalid"
-  PaymentCheckoutComponent:
-    NO_PAYMENT_METHOD: "Payment method not provided"
-    UNSUPPORTED_GATEWAY: "Gateway not supported"
-  CheckoutStep:
-    # These should probably go somewhere else, as they are pretty generic.
-    CONTINUE: "Continue"
-    SHIPPING: "Shipping"
-    SUMMARY: "Summary"
-    GRAND_TOTAL: "Grand Total"
-  CheckoutStep_Address:
-    SUPPLY_CONTACT_INFO: "Supply your contact information"
-    SEPARATE_BILLING: "Bill to a different address from this"
-    ENTER_SHIPPING_ADDRESS: "Please enter your shipping address details."
-    BILL_TO: "Bill To:"
-    SHIP_TO: "Ship To:"
-  CheckoutStep_Membership:
-    CONTINUE_AS_GUEST: "Continue as Guest"
-    # This is an option presented to the user
-    CREATE_ACCOUNT: "Create an Account"
-    # This is an action (Button label)
-    CREATE_NEW_ACCOUNT: 'Create new Account'
-  VariationForm:
-    CHOOSE_ATTRIBUTE: "Choose {attribute} …"
-    VARIATION_NOT_AVAILABLE: "That variation is not available, sorry."
-    PRODUCT_NOT_AVAILABLE: "This product is not available with the selected options."
-  PriceTag:
-    # Save as in savings (you saved this much from the original price)
-    SAVE: "Save"

--- a/templates/Includes/AccountNavigation.ss
+++ b/templates/Includes/AccountNavigation.ss
@@ -2,31 +2,31 @@
 
     <div class="nav">
 
-        <h2><%t AccountNavigation.Title 'My Account' %></h2>
+        <h2><%t AccountPage.Title 'My Account' %></h2>
 
         <ul class="nav nav-list">
 
             <li>
                 <a href="{$Link}">
-                    <i class="icon icon-list"></i><%t AccountNavigation.PastOrders 'Past Orders' %>
+                    <i class="icon icon-list"></i><%t AccountPage.PastOrders 'Past Orders' %>
                 </a>
             </li>
 
             <li>
                 <a href="{$Link('editprofile')}">
-                    <i class="icon icon-user"></i><%t AccountNavigation.EditProfile 'Edit Profile' %>
+                    <i class="icon icon-user"></i><%t AccountPage.EditProfile 'Edit Profile' %>
                 </a>
             </li>
 
             <li>
                 <a href="{$Link('addressbook')}">
-                    <i class="icon icon-book"></i><%t AccountNavigation.AddressBook 'Address Book' %>
+                    <i class="icon icon-book"></i><%t AccountPage.AddressBook 'Address Book' %>
                 </a>
             </li>
 
             <li>
                 <a href="Security/logout">
-                    <i class="icon icon-off"></i><%t AccountNavigation.LogOut 'Log Out' %>
+                    <i class="icon icon-off"></i><%t AccountPage.LogOut 'Log Out' %>
                 </a>
             </li>
 
@@ -40,19 +40,19 @@
 
             <dl>
 
-                <dt><%t AccountNavigation.MemberName 'Name' %></dt>
+                <dt><%t AccountPage.MemberName 'Name' %></dt>
                 <dd>$Name</dd>
 
-                <dt><%t AccountNavigation.MemberEmail 'Email' %></dt>
+                <dt><%t AccountPage.MemberEmail 'Email' %></dt>
                 <dd>$Email</dd>
 
-                <dt><%t AccountNavigation.MemberSince 'Member Since' %></dt>
+                <dt><%t AccountPage.MemberSince 'Member Since' %></dt>
                 <dd>$Created.Nice</dd>
 
-                <dt><%t AccountNavigation.MemberLastVisit 'Last Visit' %></dt>
+                <dt><%t AccountPage.MemberLastVisit 'Last Visit' %></dt>
                 <dd>$LastVisited.Nice</dd>
 
-                <dt> <%t AccountNavigation.NumberOfOrders 'Number of orders' %></dt>
+                <dt> <%t AccountPage.NumberOfOrders 'Number of orders' %></dt>
                 <dd><% if $PastOrders %>{$PastOrders.Count}<% else %>0<% end_if %></dd>
 
             </dl>

--- a/templates/Includes/Cart.ss
+++ b/templates/Includes/Cart.ss
@@ -1,6 +1,6 @@
 <% require themedCSS(cart,shop) %>
 <% if $Items %>
-	<table class="cart" summary="<% _t("TABLESUMMARY","Current contents of your cart.") %>">
+	<table class="cart" summary="<%t ShoppingCart.TableSummary "Current contents of your cart." %>">
 		<colgroup class="image"/>
 		<colgroup class="product title"/>
 		<colgroup class="unitprice" />
@@ -10,12 +10,12 @@
 		<thead>
 			<tr>
 				<th scope="col"></th>
-				<th scope="col"><% _t("PRODUCT","Product") %></th>
-				<th scope="col"><% _t("UNITPRICE","Unit Price") %></th>
-				<th scope="col"><% _t("QUANTITY", "Quantity") %></th>
-				<th scope="col"><% _t("TOTALPRICE","Total Price") %> ($Currency)</th>
+				<th scope="col"><%t Product.SINGULARNAME "Product" %></th>
+				<th scope="col"><%t Order.UnitPrice "Unit Price" %></th>
+				<th scope="col"><%t Order.Quantity "Quantity" %></th>
+				<th scope="col"><%t Order.TotalPrice "Total Price" %> ($Currency)</th>
 				<% if $Editable %>
-					<th scope="col"><%t CartEditField.REMOVE "Remove" %></th>
+					<th scope="col"><%t Shop.Remove "Remove" %></th>
 				<% end_if %>
 			</tr>
 		</thead>
@@ -25,7 +25,7 @@
 					<td>
 						<% if $Image %>
 							<div class="image">
-								<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Buyable.Title) %>">
+								<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">
 									$Image.setWidth(45)
 								</a>
 							</div>
@@ -34,14 +34,14 @@
 					<td id="$TableTitleID">
 						<h3>
 						<% if $Link %>
-							<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">$TableTitle</a>
+							<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">$TableTitle</a>
 						<% else %>
 							$TableTitle
 						<% end_if %>
 						</h3>
 						<% if $SubTitle %><p class="subtitle">$SubTitle</p><% end_if %>
 						<% if $Product.Variations && $Editable %>
-							<%t ShoppingCart.CHANGE "Change" %>: $VariationField
+							<%t Shop.Change "Change" %>: $VariationField
 						<% end_if %>
 					</td>
 					<td>$UnitPrice.Nice</td>
@@ -52,7 +52,7 @@
 							<% if $RemoveField %>
 								$RemoveField
 							<% else %>
-								<a href="$removeallLink" title="<% sprintf(_t("REMOVEALL","Remove all of &quot;%s&quot; from your cart"),$TableTitle) %>">
+								<a href="$removeallLink" title="<%t ShoppingCart.RemoveAllTitle "Remove all of &quot;{Title}&quot; from your cart" Title=$TableTitle %>">
 									<img src="shop/images/remove.gif" alt="x"/>
 								</a>
 							<% end_if %>
@@ -64,7 +64,7 @@
 		</tbody>
 		<tfoot>
 			<tr class="subtotal">
-				<th colspan="4" scope="row"><% _t("SUBTOTAL","Sub-total") %></th>
+				<th colspan="4" scope="row"><%t Order.SubTotal "Sub-total" %></th>
 				<td id="$TableSubTotalID">$SubTotal.Nice</td>
 				<% if $Editable %><td>&nbsp;</td><% end_if %>
 			</tr>
@@ -75,7 +75,7 @@
 							<tr id="$TableID" class="$Classes">
 								<th id="$TableTitleID" colspan="4" scope="row">
 									<% if $Link %>
-										<a href="$Link" title="<% sprintf(_t("READMORE","Click here to read more on &quot;%s&quot;"),$TableTitle) %>">$TableTitle</a>
+										<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">$TableTitle</a>
 									<% else %>
 										$TableTitle
 									<% end_if %>
@@ -85,7 +85,7 @@
 									<td>
 										<% if $CanRemove %>
 											<strong>
-												<a class="ajaxQuantityLink" href="$removeLink" title="<% sprintf(_t("REMOVE","Remove &quot;%s&quot; from your order"),$TableTitle) %>">
+												<a class="ajaxQuantityLink" href="$removeLink" title="<%t ShoppingCart.RemoveTitle "Remove &quot;{Title}&quot; from your cart." Title=$TableTitle %>">
 													<img src="shop/images/remove.gif" alt="x"/>
 												</a>
 											</strong>
@@ -102,7 +102,7 @@
 					<% end_loop %>
 				<% end_if %>
 				<tr class="gap Total">
-					<th colspan="4" scope="row"><% _t("TOTAL","Total") %></th>
+					<th colspan="4" scope="row"><%t Order.Total "Total" %></th>
 					<td id="$TableTotalID"><span class="value">$Total.Nice</span> <span class="currency">$Currency</span></td>
 					<% if $Editable %><td>&nbsp;</td><% end_if %>
 				</tr>
@@ -111,6 +111,6 @@
 	</table>
 <% else %>
 	<p class="message warning">
-		<% _t("NOITEMS","There are no items in your cart.") %>
+		<%t ShoppingCart.NoItems "There are no items in your cart." %>
 	</p>
 <% end_if %>

--- a/templates/Includes/OrderHistory.ss
+++ b/templates/Includes/OrderHistory.ss
@@ -3,11 +3,11 @@
     <thead>
 
     <tr>
-        <th><%t OrderHistory.OrderReference 'Reference' %></th>
-        <th><%t OrderHistory.OrderDate 'Date' %></th>
-        <th><%t OrderHistory.OrderItems 'Items' %></th>
-        <th><%t OrderHistory.OrderTotal 'Total' %></th>
-        <th><%t OrderHistory.OrderStatus 'Status' %></th>
+        <th><%t Order.db_Reference 'Reference' %></th>
+        <th><%t Order.Date 'Date' %></th>
+        <th><%t Order.has_many_Items 'Items' %></th>
+        <th><%t Order.Total 'Total' %></th>
+        <th><%t Order.db_Status 'Status' %></th>
         <th></th>
     </tr>
 
@@ -22,10 +22,10 @@
             <td>$Created.Nice</td>
             <td>$Items.Quantity</td>
             <td>$Total.Nice</td>
-            <td>$Status</td>
+            <td>$StatusI18N</td>
             <td>
                 <a class="btn btn-mini btn-primary" href="$Link">
-                    <i class="icon icon-white icon-eye-open"></i> <%t OrderHistory.ViewOrder 'view' %>
+                    <i class="icon icon-white icon-eye-open"></i> <%t Shop.View 'view' %>
                 </a>
             </td>
         </tr>

--- a/templates/Includes/ProductGroupItem.ss
+++ b/templates/Includes/ProductGroupItem.ss
@@ -1,26 +1,26 @@
 <div class="productItem">
 	<% if $Image %>
-		<a href="$Link" title="<% sprintf(_t("READMORE","Click here to read more on &quot;%s&quot;"),$Title) %>">
-			<img src="$Image.Thumbnail.URL" alt="<% sprintf(_t("IMAGE","%s image"),$Title) %>" />
+		<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Title %>">
+			<img src="$Image.Thumbnail.URL" alt="<%t Product.ImageAltText "{Title} image" Title=$Title %>" />
 		</a>
 	<% else %>
-		<a href="$Link" title="<% sprintf(_t("READMORE"),$Title) %>" class="noimage"><!-- no image --></a>
+		<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Title %>" class="noimage"><!-- no image --></a>
 	<% end_if %>
-	<h3 class="productTitle"><a href="$Link" title="<% sprintf(_t("READMORE"),$Title) %>">$Title</a></h3>
-	<% if $Model %><p><strong><% _t("MODEL","Model") %>:</strong> $Model.XML</p><% end_if %>
+	<h3 class="productTitle"><a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Title %>">$Title</a></h3>
+	<% if $Model %><p><strong><%t Product.Model "Model" %>:</strong> $Model.XML</p><% end_if %>
 	<div>
 		<% if $Price %><strong class="price">$Price.Nice</strong> <span class="currency">$Currency</span><% end_if %>
 		<% if $View %>
 			<div class="view">
-				<a href="$Link" title="<% sprintf(_t("VIEW","View &quot;%s&quot;"),$Title) %>">
-					<% _t("VIEW","View Product") %>
+				<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Title %>">
+					<%t Product.View "View Product" %>
 				</a>
 			</div>
 		<% else %>
 			<% if $canPurchase %>
 			<div class="add">
-				<a href="$addLink" title="<% sprintf(_t("ADD","Add &quot;%s&quot; to your cart"),$Title) %>">
-					<% _t("ADDLINK","Add to Cart") %>
+				<a href="$addLink" title="<%t Product.AddToCartTitle "Add &quot;{Title}&quot; to your cart" Title=$Title %>">
+					<%t Product.AddToCart "Add to Cart" %>
 				</a>
 			</div>
 			<% end_if %>

--- a/templates/Includes/ProductGroupPagination.ss
+++ b/templates/Includes/ProductGroupPagination.ss
@@ -1,8 +1,8 @@
 <% if $Products.MoreThanOnePage %>
 <div id="PageNumbers">
-	<p><% _t('ProductGroup.PAGE','page') %>:
+	<p><%t ProductGroup.PAGE "page" %>:
 		<% if $Products.NotFirstPage %>
-			<a class="prev" href="$Products.PrevLink" title="<%t ProductGroup.VIEW_PREVIOUS "View the previous page" %>"><% _t('ProductGroup.PREVIOUS','previous') %></a>
+			<a class="prev" href="$Products.PrevLink" title="<%t ProductGroup.VIEW_PREVIOUS "View the previous page" %>"><%t ProductGroup.PREVIOUS "previous" %></a>
 		<% end_if %>
 
 		<span>
@@ -20,7 +20,7 @@
 		</span>
 
 		<% if $Products.NotLastPage %>
-			<a class="next" href="$Products.NextLink" title="<%t ProductGroup.VIEW_NEXT "View the next page" %>"><% _t('ProductGroup.NEXT','next') %></a>
+			<a class="next" href="$Products.NextLink" title="<%t ProductGroup.VIEW_NEXT "View the next page" %>"><%t ProductGroup.NEXT "next" %></a>
 		<% end_if %>
 	</p>
 </div>

--- a/templates/Includes/ProductMenu.ss
+++ b/templates/Includes/ProductMenu.ss
@@ -3,15 +3,15 @@
  	<ul>
 		<% loop $GroupsMenu %>
  	    	<% if $Children %>
-		  	    <li class="$LinkingMode"><a href="$Link" title="<% sprintf(_t("GOTOPAGE","Go to the %s page"),$Title.XML) %>" class="$LinkingMode levela"><span><em>$MenuTitle.XML</em></span></a>
+		  	    <li class="$LinkingMode"><a href="$Link" title="<%t ProductMenu.GotoPageTitle "Go to the {Title} page" Title=$Title.XML %>" class="$LinkingMode levela"><span><em>$MenuTitle.XML</em></span></a>
   	    	<% else %>
-	  			<li><a href="$Link" title="<% sprintf(_t("GOTOPAGE","Go to the %s page"),$Title.XML) %>" class="$LinkingMode levela"><span><em>$MenuTitle.XML</em></span></a>
+	  			<li><a href="$Link" title=<%t ProductMenu.GotoPageTitle "Go to the {Title} page" Title=$Title.XML %>" class="$LinkingMode levela"><span><em>$MenuTitle.XML</em></span></a>
 			<% end_if %>
   			<% if $LinkOrSection == 'section' %>
   				<% if $ChildGroups %>
 					<ul>
 						<% loop $ChildGroups %>
-							<li><a href="$Link" title="<% sprintf(_t("GOTOPAGE","Go to the %s page"),$Title.XML) %>" class="$LinkingMode levelb">$MenuTitle.LimitCharacters(22)</a></li>
+							<li><a href="$Link" title="<%t ProductMenu.GotoPageTitle "Go to the {Title} page" Title=$Title.XML %>" class="$LinkingMode levelb">$MenuTitle.LimitCharacters(22)</a></li>
 						<% end_loop %>
 					</ul>
 		 		 <% end_if %>

--- a/templates/Includes/SideCart.ss
+++ b/templates/Includes/SideCart.ss
@@ -1,39 +1,39 @@
 <% require themedCSS(sidecart,shop) %>
 <div class="sidecart">
-	<h3><% _t("HEADLINE","My Cart") %></h3>
+	<h3><%t ShoppingCart.Headline "Shopping cart" %></h3>
 	<% if $Cart %>
 		<% with $Cart %>
 			<p class="itemcount">
 				<% if $Items.Plural %>
-					<%t ShoppingCart.ITEMS_IN_CART_PLURAL 'There are <a href="{link}">{quantity} items</a> in your cart.' link=$Top.CartLink quantity=$Items.Quantity %>
+					<%t ShoppingCart.ItemsInCartPlural 'There are <a href="{link}">{quantity} items</a> in your cart.' link=$Top.CartLink quantity=$Items.Quantity %>
 				<% else %>
-					<%t ShoppingCart.ITEMS_IN_CART_SINGULAR 'There is <a href="{link}">1 item</a> in your cart.' link=$Top.CartLink %>
+					<%t ShoppingCart.ItemsInCartSingular 'There is <a href="{link}">1 item</a> in your cart.' link=$Top.CartLink %>
 				<% end_if %>
 			</p>
 			<div class="checkout">
-				<a href="$Top.CheckoutLink"><%t ShoppingCart.CHECKOUT "Checkout" %></a>
+				<a href="$Top.CheckoutLink"><%t ShoppingCart.Checkout "Checkout" %></a>
 			</div>
 			<% loop $Items %>
 				<div class="item $EvenOdd $FirstLast">
 					<% if $Product.Image %>
 						<div class="image">
-							<a href="$Product.Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">
+							<a href="$Product.Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Title %>">
 								<% with $Product %>$Image.setWidth(45)<% end_with %>
 							</a>
 						</div>
 					<% end_if %>
 					<p class="title">
-						<a href="$Product.Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">
+						<a href="$Product.Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Title %>">
 							$TableTitle
 						</a>
 					</p>
 					<p class="quantityprice"><span class="quantity">$Quantity</span> <span class="times">x</span> <span class="unitprice">$UnitPrice.Nice</span></p>
 					<% if $SubTitle %><p class="subtitle">$SubTitle</p><% end_if %>
-					<a class="remove" href="$removeallLink" title="<% sprintf(_t("REMOVEALL","remove from cart"),$TableTitle) %>">x</a>
+					<a class="remove" href="$removeallLink" title="<%t ShoppingCart.RemoveTitle "Remove &quot;{Title}&quot; from your cart." Title=$TableTitle %>">x</a>
 				</div>
 			<% end_loop %>
 		<% end_with %>
 	<% else %>
-		<p class="noItems"><% _t("NOITEMS","There are no items in your cart") %>.</p>
+		<p class="noItems"><%t ShoppingCart.NoItems "There are no items in your cart" %>.</p>
 	<% end_if %>
 </div>

--- a/templates/Includes/VariationsTable.ss
+++ b/templates/Includes/VariationsTable.ss
@@ -1,9 +1,9 @@
 <table class="variationstable">
 	<tr>
 		<th><%t ProductVariation.SINGULARNAME "Variation" %></th>
-		<th><%t Product.PRICE "Price" %></th>
+		<th><%t Product.Price "Price" %></th>
 		<% if $canPurchase %>
-			<th><% _t("QUANTITYCART","Quantity in cart") %></th>
+			<th><%t Order.Quantity "Quantity" %></th>
 		<% end_if %>
 	</tr>
 	<% loop $Variations %>
@@ -17,7 +17,9 @@
 							$QuantityField
 						<% end_with %>
 					<% else %>
-						<a href="$Item.addLink" title="<% sprintf(_t("ADD","Add &quot;%s&quot; to your cart"),$Title.XML) %>"><% _t("ADDLINK","Add this item to cart") %></a>
+						<a href="$Item.addLink" title="<%t Product.AddToCartTitle "Add &quot;{Title}&quot; to your cart" Title=$Title.XML %>">
+                            <%t Product.AddToCart "Add to Cart" %>
+						</a>
 					<% end_if %>
 
 				<% end_if %>

--- a/templates/Layout/AccountPage.ss
+++ b/templates/Layout/AccountPage.ss
@@ -2,7 +2,7 @@
 <% include AccountNavigation %>
 <div class="typography">
     $Content
-    <h2 class="pagetitle"><%t AccountPage.Title 'Past Orders' %></h2>
+    <h2 class="pagetitle"><%t AccountPage.PastOrders 'Past Orders' %></h2>
     <% with $Member %>
         <% if $PastOrders %>
             <% include OrderHistory %>

--- a/templates/Layout/AccountPage_order.ss
+++ b/templates/Layout/AccountPage_order.ss
@@ -3,7 +3,7 @@
 <div class="typography">
 	<% if $Order %>
 		<% with $Order %>
-			<h2><% _t('AccountPage.ss.ORDER','Order') %> $Reference ($Created.Long)</h2>
+            <h2><%t Order.OrderHeadline "Order #{OrderNo} {OrderDate}" OrderNo=$Reference OrderDate=$Created.Nice %></h2>
 		<% end_with %>
 	<% end_if %>
 	<% if $Message %>

--- a/templates/Layout/CartPage.ss
+++ b/templates/Layout/CartPage.ss
@@ -14,18 +14,18 @@
 	<% end_if %>
 
 <% else %>
-	<p class="message warning"><% _t('CartPage.ss.CARTEMPTY','Your cart is empty.') %></p>
+	<p class="message warning"><%t ShoppingCart.NoItems "There are no items in your cart." %></p>
 <% end_if %>
 <div class="cartfooter">
 	<% if $ContinueLink %>
 		<a class="continuelink button" href="$ContinueLink">
-			<% _t('CartPage.ss.CONTINUE','Continue Shopping') %>
+			<%t ShoppingCart.ContinueShopping 'Continue Shopping' %>
 		</a>
 	<% end_if %>
 	<% if $Cart %>
 		<% if $CheckoutLink %>
 			<a class="checkoutlink button" href="$CheckoutLink">
-				<% _t('CartPage.ss.PROCEEDTOCHECKOUT','Proceed to Checkout') %>
+				<%t ShoppingCart.ProceedToCheckout 'Proceed to Checkout' %>
 			</a>
 		<% end_if %>
 	<% end_if %>

--- a/templates/Layout/CheckoutPage.ss
+++ b/templates/Layout/CheckoutPage.ss
@@ -5,7 +5,7 @@
 
 		<% if $PaymentErrorMessage %>
 		    <p class="message error">
-		    <% _t('CheckoutPage.PaymentErrorMessage', 'Received error from payment gateway:') %>
+		    <%t CheckoutPage.PaymentErrorMessage 'Received error from payment gateway:' %>
 		    $PaymentErrorMessage
 		    </p>
 		<% end_if %>
@@ -20,6 +20,6 @@
 		<% end_with %>
 		$OrderForm
 	<% else %>
-		<p class="message warning"><% _t('CheckoutPage.ss.CARTEMPTY','Your cart is empty.') %></p>
+		<p class="message warning"><%t ShoppingCart.NoItems "There are no items in your cart." %></p>
 	<% end_if %>
 </div>

--- a/templates/Layout/CheckoutPage_order.ss
+++ b/templates/Layout/CheckoutPage_order.ss
@@ -2,7 +2,7 @@
 	<div class="typography">
 		<% if $Order %>
 			<% with $Order %>
-				<h2><% _t('AccountPage.ss.ORDER','Order') %> $ID ($Created.Long)</h2>
+                <h2><%t Order.OrderHeadline "Order #{OrderNo} {OrderDate}" OrderNo=$Reference OrderDate=$Created.Nice %></h2>
 			<% end_with %>
 		<% end_if %>
 		<% if $Message %>

--- a/templates/Layout/Product.ss
+++ b/templates/Layout/Product.ss
@@ -12,13 +12,13 @@
 	<div class="breadcrumbs">$Breadcrumbs</div>
 	<div class="productDetails">
 		<% if $Image.ContentImage %>
-			<img class="productImage" src="$Image.ContentImage.URL" alt="<% sprintf(_t("IMAGE","%s image"),$Title) %>" />
+			<img class="productImage" src="$Image.ContentImage.URL" alt="<%t Product.ImageAltText "{Title} image" Title=$Title %>" />
 		<% else %>
-			<div class="noimage"><%t Product.NO_IMAGE "no image" %></div>
+			<div class="noimage"><%t Product.NoImage "no image" %></div>
 		<% end_if %>
-		<% if $InternalItemID %><p><% _t("CODE","Product Code") %>: {$InternalItemID}</p><% end_if %>
-		<% if $Model %><p><% _t("MODEL","Model") %>: $Model.XML</p><% end_if %>
-		<% if $Size %><p><% _t("SIZE","Size") %>: $Size.XML</p><% end_if %>
+		<% if $InternalItemID %><p><%t Product.Code "Product Code" %> : {$InternalItemID}</p><% end_if %>
+		<% if $Model %><p><%t Product.Model "Model" %> : $Model.XML</p><% end_if %>
+		<% if $Size %><p><%t Product.Size "Size" %> : $Size.XML</p><% end_if %>
 		<% if $PriceRange %>
 			<div class="price">
 				<strong class="value">$PriceRange.Min.Nice</strong>

--- a/templates/Layout/ShopDatabaseAdmin.ss
+++ b/templates/Layout/ShopDatabaseAdmin.ss
@@ -1,17 +1,16 @@
-<h3><% _t("CARTTASKS","Cart tasks") %></h3>
-<p><a href="{$BaseHref}shoppingcart/clear"><% _t("","Clear the current shopping cart") %></a></p>
-<p><a href="{$BaseHref}shoppingcart/debug"><% _t("","Debug the shopping cart") %></a></p>
+<h3><%t ShopDevelopmentAdmin.CartTasks "Cart tasks" %></h3>
+<p><a href="{$BaseHref}shoppingcart/clear"><%t ShopDevelopmentAdmin.ClearCart "Clear the current shopping cart" %></a></p>
+<p><a href="{$BaseHref}shoppingcart/debug"><%t ShopDevelopmentAdmin.DebugCart "Debug the shopping cart" %></a></p>
 
-<h3><% _t("BUILDTASKS","Build Tasks") %></h3>
+<h3><%t ShopDevelopmentAdmin.BuildTasks "Build Tasks" %></h3>
 <p>
-	<a href="{$BaseHref}dev/tasks/CartCleanupTask"><% _t("CARTCLEANUP","Cleanup old carts") %></a> 
-	- <% _t("CARTCLEANUPDESC","Remove abandoned carts.") %>
+    <a href="{$BaseHref}dev/tasks/CartCleanupTask"><%t ShopDevelopmentAdmin.CartCleanup "Cleanup old carts" %></a>
+    - <%t ShopDevelopmentAdmin.CartCleanupDesc "Remove abandoned carts." %>
+</p>
+<p>
+    <a href="{$BaseHref}dev/tasks/RecalculateAllOrdersTask"><%t ShopDevelopmentAdmin.RecalculateOrders "Recalculate all orders" %></a>
+    - <%t ShopDevelopmentAdmin.RecalculateOrdersDesc "Recalculate all order values. Warning: this will overwrite any historical values." %>
 </p>
 
-<p>
-	<a href="{$BaseHref}dev/tasks/RecalculateAllOrdersTask"><% _t("RECALCULATEORDERS","Recalculate All Orders") %></a>
-	- <% _t("RECALCULATEORDERSDESC","Recalculate all order values. Warning: this will overwrite any historical values.") %>
-</p>
-
-<h3><% _t("UNITTESTS","Unit Tests") %></h3>
-<p><a href="{$BaseHref}dev/tests/module/$ShopFolder"><% _t("RUNALLTESTS","Run all shop unit tests") %></a></p>
+<h3><%t ShopDevelopmentAdmin.UnitTests "Unit Tests" %></h3>
+<p><a href="{$BaseHref}dev/tests/module/$ShopFolder"><%t ShopDevelopmentAdmin.RunAllTests "Run all shop unit tests" %></a></p>

--- a/templates/Layout/SteppedCheckoutPage.ss
+++ b/templates/Layout/SteppedCheckoutPage.ss
@@ -3,7 +3,7 @@
 
 <% if $PaymentErrorMessage %>
 	<p class="message error">
-		<% _t('CheckoutPage.PaymentErrorMessage', 'Received error from payment gateway:') %>
+        <%t CheckoutPage.PaymentErrorMessage 'Received error from payment gateway:' %>
 		$PaymentErrorMessage
 	</p>
 <% end_if %>
@@ -43,7 +43,7 @@
 						<div class="accordion-body">
 							<div class="accordion-inner">
 								<% if $IsCurrentStep('contactdetails') %>
-									<p><%t CheckoutStep_Address.SUPPLY_CONTACT_INFO "Supply your contact information" %></p>
+									<p><%t CheckoutStep_Address.SupplyContactInformation "Supply your contact information" %></p>
 									$OrderForm
 								<% end_if %>
 								<% if $IsPastStep('contactdetails') %>
@@ -72,19 +72,19 @@
 						<div class="accordion-body">
 							<div class="accordion-inner">
 								<% if $IsCurrentStep('shippingaddress') %>
-									<p><%t CheckoutStep_Address.ENTER_SHIPPING_ADDRESS "Please enter your shipping address details." %></p>
+									<p><%t CheckoutStep_Address.EnterShippingAddress "Please enter your shipping address details." %></p>
 									$OrderForm
 								<% end_if %>
 								<% if $IsPastStep('shippingaddress') %>
 									<div class="row">
 										<div class="span4">
 											<% with $Cart %>
-												<h4><%t CheckoutStep_Address.SHIP_TO "Ship To:" %></h4>
+												<h4><%t CheckoutStep_Address.ShipTo "Ship To:" %></h4>
 												$ShippingAddress
 											<% end_with %>
 										</div>
 										<div class="span4">
-										<h4><%t CheckoutStep_Address.BILL_TO "Bill To:" %></h4>
+										<h4><%t CheckoutStep_Address.BillTo "Bill To:" %></h4>
 											<% if $IsCurrentStep('billingaddress') %>
 												$OrderForm
 											<% else %>
@@ -104,10 +104,10 @@
 					<div class="accordion-heading">
 						<% if $IsPastStep('shippingmethod') %>
 							<h3><a class="accordion-toggle" title="choose shipping method" href="$Link('shippingmethod')">
-								<%t CheckoutStep.SHIPPING "Shipping" %>
+								<%t CheckoutStep.Shipping "Shipping" %>
 							</a></h3>
 						<% else %>
-							<h3 class="accordion-toggle"><%t CheckoutStep.SHIPPING "Shipping" %></h3>
+							<h3 class="accordion-toggle"><%t CheckoutStep.Shipping "Shipping" %></h3>
 						<% end_if %>
 					</div>
 					<% if $IsFutureStep('shippingmethod') %>
@@ -132,10 +132,10 @@
 					<div class="accordion-heading">
 						<% if $IsPastStep('paymentmethod') %>
 							<h3><a class="accordion-toggle" title="choose payment method" href="$Link('paymentmethod')">
-								<%t OrderActionsForm.PAYMENTMETHOD "Payment Method" %>
+								<%t OrderActionsForm.PaymentMethod "Payment Method" %>
 							</a></h3>
 						<% else %>
-							<h3 class="accordion-toggle"><%t OrderActionsForm.PAYMENTMETHOD "Payment Method" %></h3>
+							<h3 class="accordion-toggle"><%t OrderActionsForm.PaymentMethod "Payment Method" %></h3>
 						<% end_if %>
 					</div>
 					<% if $IsFutureStep('paymentmethod') %>
@@ -156,7 +156,7 @@
 
 				<div class="accordion-group">
 					<div class="accordion-heading">
-						<h3 class="accordion-toggle"><%t CheckoutStep.SUMMARY "Summary" %></h3>
+						<h3 class="accordion-toggle"><%t CheckoutStep.Summary "Summary" %></h3>
 					</div>
 					<% if $IsFutureStep('summary') %>
 
@@ -176,7 +176,7 @@
 													<% end_if %>
 												<% end_loop %>
 												<tr>
-													<th colspan="3"><%t CheckoutStep.GRAND_TOTAL "Grand Total" %></th>
+													<th colspan="3"><%t Order.GrandTotal "Grand Total" %></th>
 													<td>$Total.Nice $Currency</td>
 												</tr>
 											</tfoot>
@@ -197,15 +197,13 @@
 <% else %>
 
 	<div class="message warning alert alert-block alert-info">
-		<h4 class="alert-heading">
-			<% _t('CartPage.ss.CARTEMPTY','Your cart is empty') %></h4>
-		<i class="icon icon-info-sign"></i> <% _t("NOITEMS","There are no items in your cart.") %>
+		<h4 class="alert-heading"><%t ShoppingCart.NoItems "There are no items in your cart." %></h4>
 	</div>
 
 	<% if $ContinueLink %>
 	<a class="continuelink btn btn-primary" href="$ContinueLink">
 		<i class="icon-arrow-left icon-white"></i>
-		<% _t('CartPage.ss.CONTINUE','Continue Shopping') %>
+        <%t ShoppingCart.ContinueShopping 'Continue Shopping' %>
 	</a>
 	<% end_if %>
 

--- a/templates/ShopDevelopmentAdmin.ss
+++ b/templates/ShopDevelopmentAdmin.ss
@@ -1,25 +1,25 @@
-<h3><% _t("CARTTASKS","Cart tasks") %></h3>
+<h3><%t ShopDevelopmentAdmin.CartTasks "Cart tasks" %></h3>
 <ul>
-	<li><a href="{$BaseHref}shoppingcart/clear"><% _t("CLEARCART","Clear the current shopping cart") %></a></li>
-	<li><a href="{$BaseHref}shoppingcart/debug"><% _t("DEBUGCART","Debug the shopping cart") %></a></li>
-	<li><a href="{$BaseHref}dev/tasks/PopulateCartTask"><% _t("POPULATECART","Populate cart with some available products") %></a></li>
+	<li><a href="{$BaseHref}shoppingcart/clear"><%t ShopDevelopmentAdmin.ClearCart "Clear the current shopping cart" %></a></li>
+	<li><a href="{$BaseHref}shoppingcart/debug"><%t ShopDevelopmentAdmin.DebugCart "Debug the shopping cart" %></a></li>
+	<li><a href="{$BaseHref}dev/tasks/PopulateCartTask"><%t ShopDevelopmentAdmin.PopulateCart "Populate cart with some available products" %></a></li>
 </ul>
 
-<h3><% _t("BUILDTASKS","Build Tasks") %></h3>
+<h3><%t ShopDevelopmentAdmin.BuildTasks "Build Tasks" %></h3>
 <ul>
-	<li><a href="{$BaseHref}dev/tasks/CartCleanupTask"><% _t("CARTCLEANUP","Cleanup old carts") %></a> 
-	- <% _t("CARTCLEANUPDESC","Remove abandoned carts.") %></li>
-	<li><a href="{$BaseHref}dev/tasks/DeleteOrdersTask"><% _t("DELETEORDERS","Delete All Orders") %></a> 
-	- <% _t("DELETEORDERSDESC","Remove all orders, modifiers, and payments from the database.") %></li>
-	<li><a href="{$BaseHref}dev/tasks/DeleteProductsTask"><% _t("DELETEPRODUCTS","Delete All Products") %></a>
-	- <% _t("DELETEPRODUCTSDESC","Remove all products from the database.") %></li>
-	<li><a href="{$BaseHref}dev/tasks/RecalculateAllOrdersTask"><% _t("RECALCULATEORDERS","Recalculate All Orders") %></a>
-	- <% _t("RECALCULATEORDERSDESC","Recalculate all order values. Warning: this will overwrite any historical values.") %></li>
-	<li><a href="{$BaseHref}dev/tasks/PopulateShopTask"><% _t("POPULATESHOP","Populate shop") %></a>
-	- <% _t("POPULATESHOPDESC","Populate the shop with dummy products, categories, and other necessary pages.") %></li>
+	<li><a href="{$BaseHref}dev/tasks/CartCleanupTask"><%t ShopDevelopmentAdmin.CartCleanup "Cleanup old carts" %></a>
+	- <%t ShopDevelopmentAdmin.CartCleanupDesc "Remove abandoned carts." %></li>
+	<li><a href="{$BaseHref}dev/tasks/DeleteOrdersTask"><%t ShopDevelopmentAdmin.DeleteOrders "Delete all orders" %></a>
+	- <%t ShopDevelopmentAdmin.DeleteOrdersDesc "Remove all orders, modifiers, and payments from the database." %></li>
+	<li><a href="{$BaseHref}dev/tasks/DeleteProductsTask"><%t ShopDevelopmentAdmin.DeleteProducts "Delete all products" %></a>
+	- <%t ShopDevelopmentAdmin.DeleteProductsDesc "Remove all products from the database." %></li>
+	<li><a href="{$BaseHref}dev/tasks/RecalculateAllOrdersTask"><%t ShopDevelopmentAdmin.RecalculateOrders "Recalculate all orders" %></a>
+	- <%t ShopDevelopmentAdmin.RecalculateOrdersDesc "Recalculate all order values. Warning: this will overwrite any historical values." %></li>
+	<li><a href="{$BaseHref}dev/tasks/PopulateShopTask"><%t ShopDevelopmentAdmin.PopulateShop "Populate shop" %></a>
+	- <%t ShopDevelopmentAdmin.PopulateShopDesc "Populate the shop with dummy products, categories, and other necessary pages." %></li>
 </ul>
 
-<h3><% _t("UNITTESTS","Unit Tests") %></h3>
+<h3><%t ShopDevelopmentAdmin.UnitTests "Unit Tests" %></h3>
 <ul>
-	<li><a href="{$BaseHref}dev/tests/module/$ShopFolder"><% _t("RUNALLTESTS","Run all shop unit tests") %></a></li>
+	<li><a href="{$BaseHref}dev/tests/module/$ShopFolder"><%t ShopDevelopmentAdmin.RunAllTests "Run all shop unit tests" %></a></li>
 </ul>

--- a/templates/ShopQuantityField.ss
+++ b/templates/ShopQuantityField.ss
@@ -1,5 +1,7 @@
 <div class="quantityfield">
-	<a class="removelink" href="$DecrementLink" title="<% sprintf(_t("REMOVEONE","Remove one of &quot;%s&quot; from your cart"),$Item.TableTitle) %>">-</a>	
+	<a class="removelink" href="$DecrementLink"
+       title="<%t ShopQuantityField.RemoveOne "Remove one of &quot;{ItemTitle}&quot; from your cart" ItemTitle=$Item.TableTitle %>">-</a>
 	<span class="quantity">$Field</span>
-	<a class="addlink" href="$IncrementLink" title="<% sprintf(_t("ADDONE","Add one more of &quot;%s&quot; to your cart"),$Item.TableTitle) %>">+</a>
+	<a class="addlink" href="$IncrementLink"
+       title="<%t ShopQuantityField.AddOne "Add one more of &quot;{ItemTitle}&quot; to your cart" ItemTitle=$Item.TableTitle %>">+</a>
 </div>

--- a/templates/admin/OrderAdmin_Addresses.ss
+++ b/templates/admin/OrderAdmin_Addresses.ss
@@ -2,12 +2,12 @@
 	<thead>
 		<tr class="title">
 			<th colspan="2">
-				<h2><% _t("ADDRESS","Address") %></h2>
+				<h2><%t Address.SINGULARNAME "Address" %></h2>
 			</th>
 		</tr>
 		<tr class="header">
-			<th class="main"><% _t("SHIPTO","Ship To") %></th>
-			<th class="main"><% _t("BILLTO","Bill To") %></th>
+			<th class="main"><%t Order.ShipTo "Ship To" %></th>
+			<th class="main"><%t Order.BillTo "Bill To" %></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/admin/OrderAdmin_Content.ss
+++ b/templates/admin/OrderAdmin_Content.ss
@@ -2,15 +2,15 @@
 	<thead>
 		<tr class="title">
 			<th colspan="5">
-				<h2><% _t("ITEMS","Items") %></h2>
+				<h2><%t OrderItem.PLURALNAME "Items" %></h2>
 			</th>
 		</tr>
 		<tr class="header">
 			<th class="main"></th>
-			<th class="main"><span class="ui-button-text"><% _t("PRODUCT","Product") %></span></th>
-			<th class="main"><span class="ui-button-text"><% _t("UNITPRICE","Unit Price") %></span></th>
-			<th class="main"><span class="ui-button-text"><% _t("QUANTITY", "Quantity") %></span></th>
-			<th class="main"><span class="ui-button-text"><% _t("TOTALPRICE","Total Price") %> ($Currency)</span></th>
+			<th class="main"><span class="ui-button-text"><%t Product.SINGULARNAME "Product" %></span></th>
+			<th class="main"><span class="ui-button-text"><%t Order.UnitPrice "Unit Price" %></span></th>
+			<th class="main"><span class="ui-button-text"><%t Order.Quantity "Quantity" %></span></th>
+			<th class="main"><span class="ui-button-text"><%t Order.TotalPriceWithCurrency "Total Price ({Currency})" Currency=$Currency %></span></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/admin/OrderAdmin_Content_ItemLine.ss
+++ b/templates/admin/OrderAdmin_Content_ItemLine.ss
@@ -2,7 +2,7 @@
 	<td>
 		<% if $Image %>
 			<div class="image">
-				<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">
+				<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$Buyable.Title %>">
 					<img src="<% with $Image.setWidth(45) %>$Me.AbsoluteURL<% end_with %>" alt="$Buyable.Title"/>
 				</a>
 			</div>
@@ -17,7 +17,7 @@
 		<% end_if %>
 		</strong>
 		<% if $SubTitle %><div class="subtitle">$SubTitle</div><% end_if %>
-		<% if $Buyable.InternalItemID %><div class="sku"><%t Product.CODE_SHORT "SKU" %>: $Buyable.InternalItemID</div><% end_if %>
+		<% if $Buyable.InternalItemID %><div class="sku"><%t Product.ProductCodeShort "SKU" %>: $Buyable.InternalItemID</div><% end_if %>
 	</td>
 	<td class="unitprice">$UnitPrice.Nice</td>
 	<td class="quantity count-$Quantity">$Quantity</td>

--- a/templates/admin/OrderAdmin_Content_SubTotals.ss
+++ b/templates/admin/OrderAdmin_Content_SubTotals.ss
@@ -1,6 +1,6 @@
 <tfoot class="order-content-subtotals">
 	<tr class="ss-gridfield-item">
-		<th colspan="4" class="main"><% _t("SUBTOTAL","Sub-total") %></th>
+		<th colspan="4" class="main"><%t Order.SubTotal "Sub-total" %></th>
 		<th class="main">$SubTotal.Nice</th>
 	</tr>
 	<% loop $Modifiers %>
@@ -15,12 +15,12 @@
 		<% end_if %>
 	<% end_loop %>
 	<tr class="ss-gridfield-item">
-		<th colspan="4" class="main"><% _t("TOTAL","Total") %></th>
+		<th colspan="4" class="main"><%t Order.Total "Total" %></th>
 		<th class="main">$Total.Nice $Currency</th>
 	</tr>
 	<% if $TotalOutstanding %>
 		<tr class="ss-gridfield-item">
-			<td colspan="4" class="main"><% _t("TOTALOUTSTANDING","Outstanding") %></td>
+			<td colspan="4" class="main"><%t Order.Outstanding "Outstanding" %></td>
 			<td class="main">$TotalOutstanding.Nice $Currency</td>
 		</tr>
 	<% end_if %>

--- a/templates/admin/OrderAdmin_Customer.ss
+++ b/templates/admin/OrderAdmin_Customer.ss
@@ -2,12 +2,12 @@
 	<thead>
 		<tr class="title">
 			<th colspan="2">
-				<h2><% _t("CUSTOMER","Customer") %></h2>
+				<h2><%t Shop.Customer "Customer" %></h2>
 			</th>
 		</tr>
 		<tr class="header">
-			<th class="main"><%t AccountNavigation.MemberName "Name" %></th>
-			<th class="main"><%t AccountNavigation.MemberEmail "Email" %></th>
+			<th class="main"><%t AccountPage.MemberName "Name" %></th>
+			<th class="main"><%t AccountPage.MemberEmail "Email" %></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/admin/OrderAdmin_Notes.ss
+++ b/templates/admin/OrderAdmin_Notes.ss
@@ -2,7 +2,7 @@
 	<thead>
 		<tr class="title">
 			<th colspan="1">
-				<h2><% _t("NOTES","Notes") %></h2>
+				<h2><%t Order.db_Notes "Notes" %></h2>
 			</th>
 		</tr>
 	</thead>

--- a/templates/admin/OrderAdmin_Printable.ss
+++ b/templates/admin/OrderAdmin_Printable.ss
@@ -6,7 +6,9 @@
 	</head>
 	<body>
 		<div style="page-break-after: always;">
-			<h1 class="title">$SiteConfig.Title <% _t("ORDER","Order") %> $Reference</h1>
+			<h1 class="title">
+                <%t OrderAdmin.ReceiptTitle "{SiteTitle} Order {OrderNo}" SiteTitle=$SiteConfig.Title OrderNo=$Reference %>
+            </h1>
 			<% include Order %>
 		</div>
 	</body>

--- a/templates/dashboard/DashboardRecentMembersPanel.ss
+++ b/templates/dashboard/DashboardRecentMembersPanel.ss
@@ -2,9 +2,9 @@
 	<table class="table table-bordered">
 		<thead>
 			<tr>
-				<td><%t AccountNavigation.MemberSince "Member Since" %></td>
-				<th><%t AccountNavigation.MemberEmail "Email" %></th>
-				<th><%t AccountNavigation.MemberName "Name" %></th>
+				<td><%t AccountPage.MemberSince "Member Since" %></td>
+				<th><%t AccountPage.MemberEmail "Email" %></th>
+				<th><%t AccountPage.MemberName "Name" %></th>
 				<th></th>
 			</tr>
 		</thead>
@@ -16,7 +16,7 @@
 					<td>$Surname, $FirstName</td>
 					<td>
 						<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/security/EditForm/field/Members/item/$ID/edit">
-							<%t ShopDashboard.EDIT "Edit" %>
+							<%t Shop.Edit "Edit" %>
 						</a>
 					</td>
 				</tr>

--- a/templates/dashboard/DashboardRecentOrdersPanel.ss
+++ b/templates/dashboard/DashboardRecentOrdersPanel.ss
@@ -4,9 +4,9 @@
 			<thead>
 				<tr>
 					<th><%t Order.db_Reference "Reference" %></th>
-					<th><%t ShopDashboard.DATE "Date" %></th>
-					<th><%t ShopDashboard.CUSTOMER "Customer" %></th>
-					<th><%t AccountNavigation.EMAIL "Email" %></th>
+					<th><%t Shop.Date "Date" %></th>
+					<th><%t Shop.Customer "Customer" %></th>
+					<th><%t AccountPage.MemberEmail "Email" %></th>
 					<th><%t Order.has_many_Items "Items" %></th>
 					<th><%t Order.db_Total "Total" %></th>
 					<th><%t Order.db_Status "Status" %></th>
@@ -22,10 +22,10 @@
 						<td>$Email</td>
 						<td>$Items.Quantity</td>
 						<td>$Total.Nice</td>
-						<td>$Status</td>
+						<td>$StatusI18N</td>
 						<td>
 							<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/orders/Order/EditForm/field/Order/item/$ID/edit">
-								<%t ShopDashboard.EDIT "Edit" %>
+								<%t Shop.Edit "Edit" %>
 							</a>
 						</td>
 					</tr>
@@ -39,7 +39,7 @@
 			<thead>
 				<tr>
           <th><%t Order.db_Reference "Reference" %></th>
-          <th><%t ShopDashboard.CUSTOMER "Customer" %></th>
+          <th><%t Shop.Customer "Customer" %></th>
           <th><%t Order.db_Total "Total" %></th>
 					<th></th>
 				</tr>
@@ -52,7 +52,7 @@
 						<td>$Total.Nice</td>
 						<td>
 							<a class="ss-ui-button ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only" role="button" aria-disabled="false" href="admin/orders/Order/EditForm/field/Order/item/$ID/edit">
-								<%t ShopDashboard.EDIT "Edit" %>
+								<%t Shop.Edit "Edit" %>
 							</a>
 						</td>
 					</tr>

--- a/templates/email/Order_AdminNotificationEmail.ss
+++ b/templates/email/Order_AdminNotificationEmail.ss
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" >
-		<title><% _t("TITLE","Shop Receipt") %></title>
+		<title><%t ShopEmail.AdminNotificationTitle "Shop Receipt" %></title>
 		<% include OrderReceiptStyle %>
 	</head>
 	<body>

--- a/templates/email/Order_ConfirmationEmail.ss
+++ b/templates/email/Order_ConfirmationEmail.ss
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" >
-		<title><% _t("TITLE", "Order Confirmation") %></title>
+		<title><%t ShopEmail.ConfirmationTitle "Order Confirmation" %></title>
 		<% include OrderReceiptStyle %>
 	</head>
 	<body>

--- a/templates/email/Order_ReceiptEmail.ss
+++ b/templates/email/Order_ReceiptEmail.ss
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" >
-		<title><% _t("TITLE","Shop Receipt") %></title>
+		<title><%t ShopEmail.ReceiptTitle "Shop Receipt" %></title>
 		<% include OrderReceiptStyle %>
 	</head>
 	<body>

--- a/templates/email/Order_StatusEmail.ss
+++ b/templates/email/Order_StatusEmail.ss
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" >
-		<title><% _t("TITLE","Shop Status Change") %></title>
+		<title><%t ShopEmail.StatusChangeTitle "Shop Status Change" %></title>
 		<style>
 			<!--
 			/** Global resetting for Design **/
@@ -97,7 +97,7 @@
 			<thead>
 				<tr>
 					<th scope="col" colspan="2">
-						<h1><% _t("HEADLINE","Shop Status Change") %></h1>
+						<h1><%t ShopEmail.StatusChangeTitle "Shop Status Change" %></h1>
 					</th>
 				</tr>
 				<tr>
@@ -111,7 +111,9 @@
 				<% with $Order %>
 					<tr>
 						<td scope="row" colspan="2" class="typography">
-							<p><% sprintf(_t("STATUSCHANGE","Status changed to \"%s\" for Order #"),$Status) %>{$ID}</p>
+							<p>
+                                <%t ShopEmail.StatusChanged 'Status for order #{OrderNo} changed to "{OrderStatus}"' OrderNo=$Reference OrderStatus=$StatusI18N %>
+                            </p>
 						</td>
 					</tr>
 				<% end_with %>

--- a/templates/order/Order.ss
+++ b/templates/order/Order.ss
@@ -9,7 +9,7 @@
 		<table id="OutstandingTable" class="infotable">
 			<tbody>
 				<tr class="gap summary" id="Outstanding">
-					<th colspan="4" scope="row" class="threeColHeader"><strong><% _t("TOTALOUTSTANDING","Total outstanding") %></strong></th>
+					<th colspan="4" scope="row" class="threeColHeader"><strong><%t Order.TotalOutstanding "Total outstanding" %></strong></th>
 					<td class="right"><strong>$TotalOutstanding.Nice </strong></td>
 				</tr>
 			</tbody>
@@ -19,7 +19,7 @@
 		<table id="NotesTable" class="infotable">
 			<thead>
 				<tr>
-					<th><% _t("ORDERNOTES","Notes") %></th>
+					<th><%t Order.db_Notes "Notes" %></th>
 				</tr>
 			</thead>
 			</tbody>

--- a/templates/order/Order_Address.ss
+++ b/templates/order/Order_Address.ss
@@ -1,7 +1,7 @@
 <table id="ShippingTable" class="infotable">
 	<tr>
-		<th><% _t("SHIPTO","Ship To") %></th>
-		<th><% _t("BILLTO","Bill To") %></th>
+		<th><%t Order.ShipTo "Ship To" %></th>
+		<th><%t Order.BillTo "Bill To" %></th>
 	</tr>
 	<tr>
 		<td>$ShippingAddress</td>

--- a/templates/order/Order_Content.ss
+++ b/templates/order/Order_Content.ss
@@ -7,10 +7,10 @@
 	<thead>
 		<tr>
 			<th scope="col"></th>
-			<th scope="col"><% _t("PRODUCT","Product") %></th>
-			<th scope="col"><% _t("UNITPRICE","Unit Price") %></th>
-			<th scope="col"><% _t("QUANTITY", "Quantity") %></th>
-			<th scope="col"><% _t("TOTALPRICE","Total Price") %> ($Currency)</th>
+			<th scope="col"><%t Product.SINGULARNAME "Product" %></th>
+			<th scope="col"><%t Order.UnitPrice "Unit Price" %></th>
+			<th scope="col"><%t Order.Quantity "Quantity" %></th>
+			<th scope="col"><%t Order.TotalPriceWithCurrency "Total Price ({Currency})" Currency=$Currency %></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/templates/order/Order_Content_ItemLine.ss
+++ b/templates/order/Order_Content_ItemLine.ss
@@ -2,7 +2,7 @@
 	<td>
 		<% if $Image %>
 			<div class="image">
-				<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">
+				<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">
 					<img src="<% with $Image.setWidth(45) %>$Me.AbsoluteURL<% end_with %>" alt="$Buyable.Title"/>
 				</a>
 			</div>
@@ -11,7 +11,7 @@
 	<td class="product title" scope="row">
 		<h3>
 		<% if $Link %>
-			<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">$TableTitle</a>
+			<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">$TableTitle</a>
 		<% else %>
 			$TableTitle
 		<% end_if %>

--- a/templates/order/Order_Content_SubTotals.ss
+++ b/templates/order/Order_Content_SubTotals.ss
@@ -1,6 +1,6 @@
 <tfoot>
 	<tr class="gap summary" id="SubTotal">
-		<td colspan="4" scope="row" class="threeColHeader subtotal"><% _t("SUBTOTAL","Sub-total") %></td>
+		<td colspan="4" scope="row" class="threeColHeader subtotal"><%t Order.SubTotal "Sub-total" %></td>
 		<td class="right">$SubTotal.Nice</td>
 	</tr>
 	<% loop $Modifiers %>
@@ -12,7 +12,7 @@
 		<% end_if %>
 	<% end_loop %>
 	<tr class="gap summary total" id="Total">
-		<td colspan="4" scope="row" class="threeColHeader total"><% _t("TOTAL","Total") %></td>
+		<td colspan="4" scope="row" class="threeColHeader total"><%t Order.Total "Total" %></td>
 		<td class="right">$Total.Nice $Currency</td>
 	</tr>
 </tfoot>

--- a/templates/order/Order_ItemLine.ss
+++ b/templates/order/Order_ItemLine.ss
@@ -2,7 +2,7 @@
 	<td>
 		<% if $Product.Image %>
 			<div class="image">
-				<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">
+				<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">
 					<% with $Product %>
 						<img src="<% with $Image.setWidth(45) %>$Me.AbsoluteURL<% end_with %>" alt="$Title"/>
 					<% end_with %>
@@ -13,7 +13,7 @@
 	<td class="product title" scope="row">
 		<h5>
 		<% if $Link %>
-			<a href="$Link" title="<% sprintf(_t("READMORE","View &quot;%s&quot;"),$Title) %>">$TableTitle</a>
+			<a href="$Link" title="<%t Shop.ReadMoreTitle "Click here to read more on &quot;{Title}&quot;" Title=$TableTitle %>">$TableTitle</a>
 		<% else %>
 			$TableTitle
 		<% end_if %>

--- a/templates/order/Order_Payments.ss
+++ b/templates/order/Order_Payments.ss
@@ -1,14 +1,14 @@
 <table id="PaymentTable" class="infotable">
 	<thead>
 		<tr class="gap mainHeader">
-				<th colspan="10" class="left"><% _t("PAYMENTS","Payment(s)") %></th>
+				<th colspan="10" class="left"><%t Payment.PaymentsHeadline "Payment(s)" %></th>
 		</tr>
 		<tr>
-			<th scope="row" class="twoColHeader"><% _t("DATE","Date") %></th>
-			<th scope="row"  class="twoColHeader"><% _t("AMOUNT","Amount") %></th>
-			<th scope="row"  class="twoColHeader"><% _t("PAYMENTSTATUS","Payment Status") %></th>
-			<th scope="row" class="twoColHeader"><% _t("PAYMENTMETHOD","Method") %></th>
-			<th scope="row" class="twoColHeader"><% _t("PAYMENTNOTE","Note") %></th>
+			<th scope="row" class="twoColHeader"><%t Payment.Date "Date" %></th>
+			<th scope="row"  class="twoColHeader"><%t Payment.Amount "Amount" %></th>
+			<th scope="row"  class="twoColHeader"><%t Payment.Status "Payment Status" %></th>
+			<th scope="row" class="twoColHeader"><%t Payment.Method "Method" %></th>
+			<th scope="row" class="twoColHeader"><%t Payment.Note "Note" %></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -16,7 +16,7 @@
 			<tr>
 				<td class="price">$Created.Nice</td>
 				<td class="price">$Amount.Nice $Currency</td>
-				<td class="price">$Status</td>
+				<td class="price">$PaymentStatus</td>
 				<td class="price">$GatewayTitle</td>
 				<td class="price">$Message.NoHTML</td>
 			</tr>


### PR DESCRIPTION
A first stab at issue #368 

Updated translation syntax across all template and PHP files.
Tried to remove redundant and outdated translations… the resulting language file went from 770 lines to ~490 Lines.
Currently only `en.yml` has been updated.

Squashed commits:
 - Merged some more translations, re-collected all translations using the text-collector. 
 - Cleaning up translations.
 - Remove some more redundant translations.
 - Merged AccountNavigation and AccountPage.
 - Merged `Cart` and `ShoppingCart`
 - Created new en file using text-collector task.
 - Changed translation keys to camel case, some were renamed for clarity.
 - Implemented `i18nEntityProvider` interface for classes that need it.
 - Replace all `sprintf` based text-substitutions with the new placeholder syntax.
 - Use capitalized keys for order-status. Reasoning: It's a generated output, similar to `SINGULARNAME` etc.
 - Updated all templates to use new template syntax. Also merged several identical translations with the same key. Process still not complete though.
 - Update Order to allow translation of Order-Status.