### PR TITLE
Add Locale information to Order. Fixes #403

### DIFF
--- a/code/ShopTools.php
+++ b/code/ShopTools.php
@@ -13,4 +13,43 @@ class ShopTools{
 		return $field;
 	}
 
+    public static function get_current_locale()
+    {
+        if(class_exists('Translatable')){
+            return Translatable::get_current_locale();
+        }
+
+        if(class_exists('Fluent')){
+            return Fluent::current_locale();
+        }
+
+        return i18n::get_locale();
+    }
+
+    public static function install_locale($locale)
+    {
+        // If the locale isn't given, silently fail (there might be carts that still have locale set to null)
+        if(empty($locale)){
+            return;
+        }
+
+        if(class_exists('Translatable')){
+            Translatable::set_current_locale($locale);
+        } else if(class_exists('Fluent')){
+            Fluent::set_persist_locale($locale);
+        }
+
+        // Do something like Fluent does to install the locale
+        i18n::set_locale($locale);
+
+        // LC_NUMERIC causes SQL errors for some locales (comma as decimal indicator) so skip
+        foreach (array(LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_TIME) as $category) {
+            setlocale($category, "{$locale}.UTF-8", $locale);
+        }
+        // Get date/time formats from Zend
+        require_once 'Zend/Date.php';
+        i18n::config()->date_format = Zend_Locale_Format::getDateFormat($locale);
+        i18n::config()->time_format = Zend_Locale_Format::getTimeFormat($locale);
+    }
+
 }

--- a/code/cart/CartForm.php
+++ b/code/cart/CartForm.php
@@ -27,6 +27,13 @@ class CartForm extends Form{
 	public function updatecart($data, $form) {
 		$items = $this->cart->Items();
 		$updatecount = $removecount = 0;
+
+        $request = $this->getRequest();
+        $order = ShoppingCart::curr();
+        if($request && $request->isAjax() && $order){
+            ShopTools::install_locale($order->Locale);
+        }
+
 		$messages = array();
 		if(isset($data['Items']) && is_array($data['Items'])){
 			foreach($data['Items'] as $itemid => $fields){
@@ -79,7 +86,7 @@ class CartForm extends Form{
 			$form->sessionMessage(implode(" ", $messages), "good");
 		}
 
-		$request = $this->getRequest();
+
 		$this->extend('updateCartFormResponse', $request, $response, $form);
 
 		return $response ? $response : $this->controller->redirectBack();

--- a/code/cart/ShoppingCart.php
+++ b/code/cart/ShoppingCart.php
@@ -495,6 +495,7 @@ class ShoppingCart_Controller extends Controller{
 			$this->cart->add($product, $quantity, $request->getVars());
 		}
 
+        $this->updateLocale($request);
 		$this->extend('updateAddResponse', $request, $response, $product, $quantity);
 		return $response ? $response : self::direct();
 	}
@@ -509,6 +510,7 @@ class ShoppingCart_Controller extends Controller{
 			$this->cart->remove($product, $quantity = 1, $request->getVars());
 		}
 
+        $this->updateLocale($request);
 		$this->extend('updateRemoveResponse', $request, $response, $product, $quantity);
 		return $response ? $response : self::direct();
 	}
@@ -523,6 +525,7 @@ class ShoppingCart_Controller extends Controller{
 			$this->cart->remove($product, null, $request->getVars());
 		}
 
+        $this->updateLocale($request);
 		$this->extend('updateRemoveAllResponse', $request, $response, $product);
 		return $response ? $response : self::direct();
 	}
@@ -540,6 +543,7 @@ class ShoppingCart_Controller extends Controller{
 			$this->cart->setQuantity($product, $quantity, $request->getVars());
 		}
 
+        $this->updateLocale($request);
 		$this->extend('updateSetQuantityResponse', $request, $response, $product, $quantity);
 		return $response ? $response : self::direct();
 	}
@@ -551,6 +555,7 @@ class ShoppingCart_Controller extends Controller{
 	 * @return AjaxHTTPResponse|bool
 	 */
 	public function clear($request) {
+        $this->updateLocale($request);
 		$this->cart->clear();
 		$this->extend('updateClearResponse', $request, $response);
 		return $response ? $response : self::direct();
@@ -583,5 +588,13 @@ class ShoppingCart_Controller extends Controller{
 			return array('Content' => $content);
 		}
 	}
+
+    protected function updateLocale($request)
+    {
+        $order = $this->cart->current();
+        if($request && $request->isAjax() && $order){
+            ShopTools::install_locale($order->Locale);
+        }
+    }
 
 }

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -147,7 +147,9 @@ class OrderProcessor{
 			//place the order, if not already placed
 			if($this->canPlace($this->order)){
 				$this->placeOrder();
-			}
+			} else if($this->order->Locale){
+                ShopTools::install_locale($this->order->Locale);
+            }
 
 			if(
 				// Standard order
@@ -207,6 +209,11 @@ class OrderProcessor{
 		if(!$this->canPlace($this->order)){ //final cart validation
 			return false;
 		}
+
+        if($this->order->Locale){
+            ShopTools::install_locale($this->order->Locale);
+        }
+
 		//remove from session
 		$cart = ShoppingCart::curr();
 		if($cart && $cart->ID == $this->order->ID){

--- a/code/model/Order.php
+++ b/code/model/Order.php
@@ -37,7 +37,9 @@ class Order extends DataObject {
 		'Notes' => 'Text',
 		'IPAddress' => 'Varchar(15)',
 		//separate shipping
-		'SeparateBillingAddress' => 'Boolean'
+		'SeparateBillingAddress' => 'Boolean',
+        // keep track of customer locale
+        'Locale' => 'DBLocale'
 	);
 
 	private static $has_one = array(
@@ -510,6 +512,12 @@ class Order extends DataObject {
 		if(!$this->getField("Reference") && in_array($this->Status, self::$placed_status)){
 			$this->generateReference();
 		}
+
+        // While the order is unfinished/cart, always store the current locale with the order.
+        // We do this everytime an order is saved, because the user might change locale (language-switch).
+        if($this->Status == 'Cart'){
+            $this->Locale = ShopTools::get_current_locale();
+        }
 	}
 
 	/**

--- a/code/product/AddProductForm.php
+++ b/code/product/AddProductForm.php
@@ -51,6 +51,13 @@ class AddProductForm extends Form {
 	public function addtocart($data,$form){
 		if($buyable = $this->getBuyable($data)){
 			$cart = ShoppingCart::singleton();
+			$request = $this->getRequest();
+
+            $order = $cart->current();
+            if($request && $request->isAjax() && $order){
+                ShopTools::install_locale($order->Locale);
+            }
+
 			$saveabledata = (!empty($this->saveablefields)) ? Convert::raw2sql(array_intersect_key($data,array_combine($this->saveablefields,$this->saveablefields))) : $data;
 			$quantity = isset($data['Quantity']) ? (int) $data['Quantity']: 1;
 			$cart->add($buyable,$quantity,$saveabledata);
@@ -60,7 +67,6 @@ class AddProductForm extends Form {
 
 			$this->extend('updateAddToCart', $form, $buyable);
 
-			$request = $this->getRequest();
 			$this->extend('updateAddProductFormResponse', $request, $response, $buyable, $quantity, $form);
 
 			return $response ? $response : ShoppingCart_Controller::direct($cart->getMessageType());

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -68,6 +68,12 @@ class VariationForm extends AddProductForm {
 		if($variation = $this->getBuyable($data)) {
 			$quantity = (isset($data['Quantity']) && is_numeric($data['Quantity'])) ? (int) $data['Quantity'] : 1;
 			$cart = ShoppingCart::singleton();
+		    $request = $this->getRequest();
+
+            $order = $cart->current();
+            if($request && $request->isAjax() && $order){
+                ShopTools::install_locale($order->Locale);
+            }
 
 			// if we are in just doing a validation step then check
 			if($this->request->requestVar('ValidateVariant')) {
@@ -112,7 +118,6 @@ class VariationForm extends AddProductForm {
 
 		$this->extend('updateVariationAddToCart', $form, $variation);
 
-		$request = $this->getRequest();
 		$this->extend('updateVariationFormResponse', $request, $response, $variation, $quantity, $form);
 		return $response ? $response : ShoppingCart_Controller::direct();
 	}


### PR DESCRIPTION
Added locale db-field to order.
Added helper tools to get/set current locale.
Ensure locale is properly saved while an order is in `Cart` state.
Install the saved locale during order processing.
Install order-locale for ajax requests to ensure ajax response is rendered with the proper locale.