### PR TITLE
Fixed issue with address duplication due to blank or readonly fields

### DIFF
--- a/code/checkout/components/AddressCheckoutComponent.php
+++ b/code/checkout/components/AddressCheckoutComponent.php
@@ -61,6 +61,14 @@ abstract class AddressCheckoutComponent extends CheckoutComponent
     public function setData(Order $order, array $data)
     {
         $address = $this->getAddress($order);
+        //if the value matches the current address then unset
+        //this is to fix issues with blank fields & the readonly Country field
+        $addressinfo = $address->toMap();
+        foreach($data as $key => $value) {
+            if(!isset($addressinfo[$key]) || $addressinfo[$key] === $value) {
+                unset($data[$key]);
+            }
+        }
         $address->update($data);
         //if only one country is available, then set it
         if ($country = SiteConfig::current_site_config()->getSingleCountry()) {

--- a/code/model/Address.php
+++ b/code/model/Address.php
@@ -68,6 +68,18 @@ class Address extends DataObject
         'toString' => 'Address',
     );
 
+    public function toMap() {
+        $address = parent::toMap();
+
+        $fields = self::database_fields(get_class($this));
+        foreach(array_keys($fields) as $field) {
+            if(!isset($address[$field])) {
+                $address[$field] = '';
+            }
+        }
+        return $address;
+    }
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();


### PR DESCRIPTION
The issue with this is that the readonly Country field which is added to the fieldlist (when there is only 1 selectable country) for an address causes the address to always duplicate.

This means you end up with a lot of addresses in your database even if you don't change your address.

The other issue with this is that blank fields cause the same issue as above because for some reason silverstripe doesn't populate the dataobject's record with blank fields. This means when it does the changed check it thinks things have changed even if they haven't.